### PR TITLE
Burn down editor docs and package smoke issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - run: pnpm test:package-smoke
       - run: pnpm test
       - run: pnpm lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
+      - run: pnpm test:package-smoke
 
       - name: Publish @elucim/core
         if: ${{ needs.release-please.outputs.core_release == 'true' }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ packages/
 # Unit tests (429 tests across core, dsl, editor)
 pnpm test
 
+# Packed package smoke tests (requires pnpm build first; installs tarballs with npm)
+pnpm build
+pnpm test:package-smoke
+
 # Individual packages
 pnpm --filter @elucim/core test
 pnpm --filter @elucim/dsl test

--- a/docs/src/content/docs/editor/inspector.mdx
+++ b/docs/src/content/docs/editor/inspector.mdx
@@ -54,12 +54,12 @@ Use the inspector for an element's static starting state. Use the motion panel f
 
 | Motion concept | Where to edit |
 |----------------|---------------|
-| Timeline duration | Animate workspace, selected timeline details |
-| Tracks | Animate workspace |
-| Keyframes | Animate workspace details pane |
-| Easing | Animate workspace keyframe controls |
-| State machine states | State Machine workspace graph |
-| Transitions / triggers | State Machine workspace graph and details |
+| Timeline duration | Animations motion tab, selected timeline details |
+| Tracks | Animations motion tab |
+| Keyframes | Animations motion tab details pane |
+| Easing | Animations motion tab keyframe controls |
+| State machine states | State machines motion tab graph |
+| Transitions / triggers | State machines motion tab graph and details |
 
 The inspector does not create wrapper animation props. Legacy documents that already contain wrapper nodes can still be inspected through Objects, but new motion should be authored in timelines and state machines.
 

--- a/docs/src/content/docs/editor/overview.mdx
+++ b/docs/src/content/docs/editor/overview.mdx
@@ -21,7 +21,7 @@ export function App() {
 }
 ```
 
-This opens the full editor shell with workspace tabs, an Objects/Create dock, canvas, inspector, zoom controls, minimap, and the motion panel.
+This opens the full editor shell with an Objects/Create/Polish dock, canvas, inspector, zoom controls, minimap, and the motion panel.
 
 <img class="theme-img-dark" src="/images/editor/editor-overview-dark.png" alt="Elucim editor in dark mode showing dense canvas, Objects, inspector, and motion panel" />
 <img class="theme-img-light" src="/images/editor/editor-overview-light.png" alt="Elucim editor in light mode showing dense canvas, Objects, inspector, and motion panel" />
@@ -87,36 +87,39 @@ export function App() {
 
 `initialFrame` can be a frame number or `'last'`, which is useful when opening generated documents with reveal timelines.
 
-## Workspace model
+## Editor model
 
-The editor is organized around four workspaces:
+The editor no longer asks you to switch between broad Design, Animate, State Machine, and Polish workspace presets. The persistent shell keeps the same core surfaces visible so the document model stays obvious:
 
-| Workspace | Use it for |
-|-----------|------------|
-| **Design** | Arrange Objects, browse scene structure, add templates, edit static properties, group, align, and distribute. |
-| **Animate** | Create and edit timelines, tracks, keyframes, easing, and sampled timeline preview frames. |
-| **State Machine** | Wire timelines into Entry/state/Exit flows, transitions, trigger inputs, keyboard/click events, and preview behavior. |
-| **Polish** | Review metadata, selected-element intent, validation warnings, compatibility notes, and suggested document nudges. |
+| Surface | Use it for |
+|---------|------------|
+| **Objects** | Browse the scene tree, select Objects, inspect generated IDs, understand groups, and reorder scene structure. |
+| **Create** | Add template Objects to the scene. Templates become normal Elucim Document elements. |
+| **Polish** | Review scene metadata, selected-object intent, validation warnings, compatibility notes, polish diagnostics, and suggested document nudges. |
+| **Inspector** | Edit the selected canvas or Object's static properties, layout, style, transforms, and group details. |
+| **Timeline** | Edit animation timelines, property tracks, keyframes, easing, and preview frames. |
+| **Animations motion tab** | Author timeline-based motion for Objects. |
+| **State machines motion tab** | Wire timelines into Entry/state/Exit flows, transitions, trigger inputs, keyboard/click events, and preview behavior. |
 
-Normalized documents open in **Animate** by default so existing timelines are immediately visible. New blank editor sessions start in **Design**.
+Normalized documents open with motion visible so existing animations are immediately inspectable. New blank editor sessions emphasize Objects and the inspector first.
 
 ## Layout
 
-The current editor shell is a docked workspace UI:
+The current editor shell is a docked scene-editing UI:
 
 | Region | Purpose |
 |--------|---------|
-| **Top bar** | Workspace tabs plus show/hide toggles for left panel, inspector, and timeline. |
-| **Left dock** | `Objects` tab for scene structure and `Create` tab for element templates. |
+| **Top bar** | Show/hide toggles for the left panel, inspector, and timeline. |
+| **Left dock** | `Objects` for scene structure, `Create` for element templates, and `Polish` for diagnostics and nudges. |
 | **Canvas** | Pan/zoom stage with grid, selection overlay, context menu, minimap, and zoom controls. |
 | **Inspector** | Contextual properties for the canvas or selected element. |
-| **Motion panel** | Timeline editor or state-machine graph, depending on workspace/tab. |
+| **Motion panel** | Animations and State machines motion tabs for timeline editing and state-machine graphs. |
 
 The left dock, inspector, and timeline are resizable. Hidden regions can be restored from the top bar or the collapsed rail.
 
 ## Creating elements
 
-Open the **Create** tab in the left dock and choose from the template palette:
+Open **Create** in the left dock and choose from the template palette:
 
 | Category | Templates |
 |----------|-----------|
@@ -127,7 +130,7 @@ Open the **Create** tab in the left dock and choose from the template palette:
 | **Math** | Axes, Function Plot, Vector, Vector Field, Matrix |
 | **Data** | Bar Chart, Graph |
 
-Templates insert normal scene elements with sensible tokenized colors. Select the new element and use the inspector for static properties, then use timelines/state machines for motion.
+Templates insert normal scene Objects with sensible tokenized colors. Select the new Object and use the inspector for static properties, then use timelines/state machines for motion.
 
 ## Selecting and arranging
 
@@ -144,8 +147,8 @@ Templates insert normal scene elements with sensible tokenized colors. Select th
 
 Motion is not authored as wrapper JSX. Use:
 
-1. **Timelines** for property tracks and keyframes on `opacity`, `translate`, `scale`, `rotate`, `fill`, or `stroke`.
-2. **State machines** to decide when timelines run and how users can move through animated states.
+1. **Animations** in the motion panel for timeline property tracks and keyframes on `opacity`, `translate`, `scale`, `rotate`, `fill`, or `stroke`.
+2. **State machines** in the motion panel to decide when timelines run and how users can move through animated states.
 3. **Preview controls** to scrub frames, play animation, or trigger state-machine events.
 
 <img class="theme-img-dark" src="/images/editor/editor-timeline.png" alt="Dense editor timeline with animation tracks and keyframes" />

--- a/docs/src/content/docs/editor/theming.mdx
+++ b/docs/src/content/docs/editor/theming.mdx
@@ -161,8 +161,8 @@ This is the same approach used by panel, tab, selection, and graph controls.
 
 When you change editor tokens, inspect both color schemes with dense scenes that show:
 
-- top workspace tabs and panel toggles,
-- left Objects/Create dock,
+- top panel toggles,
+- left Objects/Create/Polish dock,
 - selected canvas content,
 - inspector form fields,
 - timeline tracks and keyframes,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm --filter @elucim/core build && pnpm --filter @elucim/dsl build && pnpm --filter @elucim/cli build && pnpm --filter @elucim/editor build && pnpm --filter elucim-app build",
     "test": "pnpm test:guardrails && pnpm --filter @elucim/core test && pnpm --filter @elucim/dsl test && pnpm --filter @elucim/cli test && pnpm --filter @elucim/editor test && pnpm --filter elucim-app test",
     "test:guardrails": "node scripts/guardrails.mjs",
+    "test:package-smoke": "node scripts/package-smoke.mjs",
     "test:dsl": "pnpm --filter @elucim/dsl test",
     "test:e2e": "pnpm --filter @elucim/e2e test",
     "test:e2e:all": "pnpm --filter @elucim/e2e test:all",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,192 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const packages = [
+  { name: '@elucim/core', directory: 'packages/core' },
+  { name: '@elucim/dsl', directory: 'packages/dsl' },
+  { name: '@elucim/editor', directory: 'packages/editor' },
+  { name: '@elucim/cli', directory: 'packages/cli' },
+];
+
+const tempRoot = await mkdtemp(join(tmpdir(), 'elucim-package-smoke-'));
+
+try {
+  const packedDir = join(tempRoot, 'packed');
+  const consumerDir = join(tempRoot, 'consumer');
+  await mkdir(packedDir, { recursive: true });
+  await mkdir(consumerDir, { recursive: true });
+
+  const tarballs = new Map();
+  for (const packageInfo of packages) {
+    const packageJson = await readPackageJson(packageInfo.directory);
+    ensureBuiltEntryPoints(packageInfo.directory, packageJson);
+    run(pnpm, ['--filter', packageInfo.name, 'pack', '--pack-destination', packedDir], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    });
+    const tarball = join(packedDir, packageTarballName(packageJson));
+    if (!existsSync(tarball)) {
+      throw new Error(`Expected packed artifact ${tarball} for ${packageInfo.name}`);
+    }
+    tarballs.set(packageInfo.name, tarball);
+  }
+
+  await writeFile(
+    join(consumerDir, 'package.json'),
+    `${JSON.stringify({
+      name: 'elucim-packed-artifact-smoke',
+      private: true,
+      type: 'module',
+      dependencies: {
+        '@elucim/core': fileDependency(consumerDir, tarballs.get('@elucim/core')),
+        '@elucim/dsl': fileDependency(consumerDir, tarballs.get('@elucim/dsl')),
+        '@elucim/editor': fileDependency(consumerDir, tarballs.get('@elucim/editor')),
+        '@elucim/cli': fileDependency(consumerDir, tarballs.get('@elucim/cli')),
+        jsdom: '^28.1.0',
+        react: '^18.3.0',
+        'react-dom': '^18.3.0',
+      },
+    }, null, 2)}\n`,
+  );
+
+  run(npm, ['install', '--package-lock=false', '--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'], {
+    cwd: consumerDir,
+    stdio: 'inherit',
+  });
+
+  const smokeFile = join(consumerDir, 'smoke.mjs');
+  await writeFile(smokeFile, smokeSource());
+  execFileSync(process.execPath, [smokeFile], { cwd: consumerDir, stdio: 'inherit' });
+  console.log('Packed package smoke tests passed.');
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+function run(command, args, options) {
+  if (process.platform === 'win32') {
+    return execFileSync(process.env.ComSpec ?? 'cmd.exe', ['/d', '/s', '/c', [command, ...args].map(quoteWindowsArg).join(' ')], {
+      ...options,
+      windowsHide: true,
+    });
+  }
+  return execFileSync(command, args, {
+    ...options,
+    windowsHide: true,
+  });
+}
+
+function quoteWindowsArg(value) {
+  if (!/[\s"]/u.test(value)) return value;
+  return `"${value.replaceAll('"', '\\"')}"`;
+}
+
+async function readPackageJson(packageDirectory) {
+  return JSON.parse(await readFile(resolve(repoRoot, packageDirectory, 'package.json'), 'utf8'));
+}
+
+function ensureBuiltEntryPoints(packageDirectory, packageJson) {
+  const packageRoot = resolve(repoRoot, packageDirectory);
+  for (const target of collectExportTargets(packageJson.exports)) {
+    const filePath = resolve(packageRoot, target);
+    if (!existsSync(filePath)) {
+      throw new Error(`${packageJson.name} export target is missing: ${target}. Run pnpm build before pnpm test:package-smoke.`);
+    }
+  }
+  if (packageJson.bin) {
+    const binTargets = typeof packageJson.bin === 'string' ? [packageJson.bin] : Object.values(packageJson.bin);
+    for (const target of binTargets) {
+      const filePath = resolve(packageRoot, target);
+      if (!existsSync(filePath)) {
+        throw new Error(`${packageJson.name} bin target is missing: ${target}. Run pnpm build before pnpm test:package-smoke.`);
+      }
+    }
+  }
+}
+
+function collectExportTargets(exportsValue) {
+  if (!exportsValue) return [];
+  if (typeof exportsValue === 'string') return [exportsValue];
+  if (Array.isArray(exportsValue)) return exportsValue.flatMap(collectExportTargets);
+  if (typeof exportsValue === 'object') {
+    return Object.values(exportsValue).flatMap(collectExportTargets);
+  }
+  return [];
+}
+
+function packageTarballName(packageJson) {
+  const packageFileName = packageJson.name.replace(/^@/, '').replaceAll('/', '-');
+  return `${packageFileName}-${packageJson.version}.tgz`;
+}
+
+function fileDependency(consumerDir, tarball) {
+  return `file:${relative(consumerDir, tarball).replaceAll('\\', '/')}`;
+}
+
+function smokeSource() {
+  return `import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import React from 'react';
+import { Circle, Player, interpolate } from '@elucim/core';
+import { normalizeDocument, validateDocument } from '@elucim/dsl';
+
+const consumerDir = dirname(fileURLToPath(import.meta.url));
+const cliEntry = join(consumerDir, 'node_modules', '@elucim', 'cli', 'dist', 'index.js');
+assert.equal(Boolean(Player), true, '@elucim/core Player export should import');
+assert.equal(Boolean(Circle), true, '@elucim/core Circle export should import');
+assert.equal(interpolate(5, [0, 10], [0, 100]), 50, '@elucim/core interpolate should run');
+
+const document = {
+  version: '2.0',
+  scene: {
+    type: 'player',
+    width: 640,
+    height: 360,
+    children: ['title'],
+  },
+  elements: {
+    title: {
+      id: 'title',
+      type: 'text',
+      role: 'title',
+      props: { type: 'text', content: 'Smoke test', x: 320, y: 80, fill: '$title', fontSize: 32 },
+    },
+  },
+};
+const validation = validateDocument(document);
+assert.equal(validation.valid, true, validation.errors.map(error => error.message).join('\\n'));
+assert.equal(normalizeDocument(document).document.scene.children[0], 'title', '@elucim/dsl normalizeDocument should run');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.SVGElement = dom.window.SVGElement;
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const editor = await import('@elucim/editor');
+assert.equal(typeof editor.ElucimEditor, 'function', '@elucim/editor ElucimEditor export should import');
+assert.equal(editor.createDefaultDocument().root.type, 'player', '@elucim/editor createDefaultDocument should run');
+assert.equal(React.isValidElement(React.createElement(editor.ElucimEditor, {})), true, '@elucim/editor component should be usable with React');
+
+assert.equal(existsSync(cliEntry), true, '@elucim/cli dist entry should exist');
+const opsOutput = execFileSync(process.execPath, [cliEntry, 'ops', '--json'], { encoding: 'utf8' });
+const ops = JSON.parse(opsOutput);
+assert.equal(Array.isArray(ops.cli?.commands), true, '@elucim/cli ops should return command catalog JSON');
+assert.equal(ops.cli.commands.some(command => command.name === 'validate'), true, '@elucim/cli command catalog should include validate');
+`;
+}


### PR DESCRIPTION
## Summary
- updates editor docs for the current Objects/Create/Polish dock and motion-tab model
- adds packed-artifact package smoke tests for core, dsl, editor, and cli
- wires the smoke test into CI and release validation before publish

Fixes #47
Fixes #50

## Validation
- pnpm build
- pnpm test:package-smoke
- pnpm test:guardrails
- pnpm --filter ./docs build
- pnpm lint
- pnpm test