### PR TITLE
Split Timeline into focused motion components

### DIFF
--- a/packages/e2e/tests/cli-editor-roundtrip.spec.ts
+++ b/packages/e2e/tests/cli-editor-roundtrip.spec.ts
@@ -124,12 +124,12 @@ test.describe('CLI to editor round trip', () => {
       const cliDocument = await makeCliAuthoredDocument(dir);
       await loadDocumentInEditor(page, cliDocument);
 
-      await page.getByRole('tab', { name: 'Design workspace' }).click();
+      await page.getByRole('tab', { name: 'Objects' }).click();
       await expect(page.getByRole('treeitem').filter({ hasText: 'concept-card' })).toBeVisible();
       await expect(page.getByRole('treeitem').filter({ hasText: 'concept-title' })).toBeVisible();
       await expect(page.locator('[data-editor-id="concept-card"]')).toBeVisible();
 
-      await page.getByRole('tab', { name: 'State Machine workspace' }).click();
+      await page.getByRole('tab', { name: 'State machines motion tab' }).click();
       await expect(page.getByLabel('State machine graph presentation')).toBeVisible();
       const conceptCard = page.locator('[data-measure-id="concept-card"] [data-testid="elucim-rect"]').first();
       expect(Number(await conceptCard.getAttribute('opacity'))).toBeLessThan(0.01);
@@ -138,7 +138,6 @@ test.describe('CLI to editor round trip', () => {
       await expect(page.getByText(/Previewing intro/)).toBeVisible();
       await expect.poll(async () => Number(await conceptCard.getAttribute('opacity')), { timeout: 6000 }).toBeGreaterThan(0.99);
 
-      await page.getByRole('tab', { name: 'Design workspace' }).click();
       await page.getByRole('tab', { name: 'Create' }).click();
       await page.getByTitle('Rectangle').click();
       await expect(page.locator('[data-editor-id^="rect-"]').first()).toBeVisible();
@@ -168,11 +167,11 @@ test.describe('CLI to editor round trip', () => {
     const fixtureDocument = JSON.parse(await readFile(animatedFixturePath, 'utf8'));
     await loadDocumentInEditor(page, fixtureDocument);
 
-    await page.getByRole('tab', { name: 'Design workspace' }).click();
+    await page.getByRole('tab', { name: 'Objects' }).click();
     await expect(page.getByRole('treeitem', { name: /agent-card group/ })).toBeVisible();
     await expect(page.getByRole('treeitem', { name: /agent-card-title title/ })).toBeVisible();
 
-    await page.getByRole('tab', { name: 'State Machine workspace' }).click();
+    await page.getByRole('tab', { name: 'State machines motion tab' }).click();
     await expect(page.getByLabel('State machine graph presentation')).toBeVisible();
     const cardBackground = page.locator('[data-measure-id="agent-card"] [data-testid="elucim-rect"]').first();
     expect(Number(await cardBackground.getAttribute('opacity'))).toBeLessThan(0.01);
@@ -181,7 +180,6 @@ test.describe('CLI to editor round trip', () => {
     await expect(page.getByText(/Previewing intro/)).toBeVisible();
     await expect.poll(async () => Number(await cardBackground.getAttribute('opacity')), { timeout: 6000 }).toBeGreaterThan(0.99);
 
-    await page.getByRole('tab', { name: 'Design workspace' }).click();
     await page.getByRole('button', { name: 'Exit state machine preview mode' }).click();
     await page.getByRole('tab', { name: 'Create' }).click();
     await page.getByTitle('Circle').click();

--- a/packages/e2e/tests/core-workflows.spec.ts
+++ b/packages/e2e/tests/core-workflows.spec.ts
@@ -28,7 +28,7 @@ test.describe('core editor workflows', () => {
 
   test('previews animations embedded in the state machine', async ({ page }) => {
     await openEditor(page);
-    await page.getByRole('tab', { name: 'State Machine workspace' }).click();
+    await page.getByRole('tab', { name: 'State machines motion tab' }).click();
     await expect(page.getByLabel('State machine graph walkthrough')).toBeVisible();
 
     const introRect = page.locator('[data-measure-id="rect-1"] [data-testid="elucim-rect"]').first();

--- a/packages/e2e/tests/editor-shell.spec.ts
+++ b/packages/e2e/tests/editor-shell.spec.ts
@@ -7,18 +7,11 @@ async function openEditor(page: Page) {
   await expect(page.locator('.elucim-editor')).toBeVisible({ timeout: 15000 });
 }
 
-async function expectWorkspaceSelected(page: Page, name: string) {
-  await expect(page.getByRole('tab', { name })).toHaveAttribute('aria-selected', 'true');
-}
-
 test.describe('editor shell', () => {
   test('keeps extracted chrome, panels, and workspace surfaces wired together', async ({ page }) => {
     await openEditor(page);
 
     await expect(page.getByText('Scene editor')).toBeVisible();
-    await expect(page.getByRole('tablist', { name: 'Editor workspace' })).toBeVisible();
-    await page.getByRole('tab', { name: 'Design workspace' }).click();
-    await expectWorkspaceSelected(page, 'Design workspace');
     await expect(page.getByRole('tablist', { name: 'Left editor panel' })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Objects' })).toHaveAttribute('aria-selected', 'true');
     await expect(page.locator('.elucim-editor-canvas')).toBeVisible();
@@ -32,27 +25,28 @@ test.describe('editor shell', () => {
     await page.getByRole('button', { name: /^Show left panel$/i }).first().click();
     await expect(page.getByRole('tab', { name: 'Objects' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Hide Inspector' }).click();
+    await page.getByRole('button', { name: /^Show inspector$/i }).first().click();
+    await expect(page.locator('.elucim-editor-inspector')).toBeVisible();
+    await page.getByRole('button', { name: /^Hide inspector$/i }).click();
     await expect(page.locator('.elucim-editor-inspector')).not.toBeVisible();
     await page.getByRole('button', { name: /^Show inspector$/i }).first().click();
     await expect(page.locator('.elucim-editor-inspector')).toBeVisible();
 
-    await page.getByRole('tab', { name: 'Animate workspace' }).click();
-    await expectWorkspaceSelected(page, 'Animate workspace');
+    await page.getByRole('tab', { name: 'Animations motion tab' }).click();
     await expect(page.getByRole('tab', { name: 'Animations motion tab' })).toHaveAttribute('aria-selected', 'true');
 
-    await page.getByRole('tab', { name: 'State Machine workspace' }).click();
-    await expectWorkspaceSelected(page, 'State Machine workspace');
+    await page.getByRole('tab', { name: 'State machines motion tab' }).click();
     await expect(page.getByLabel('State machine graph walkthrough')).toBeVisible();
     await expect(page.getByRole('tab', { name: 'State machines motion tab' })).toHaveAttribute('aria-selected', 'true');
 
     await page.getByRole('button', { name: 'Hide Timeline' }).click();
     await expect(page.getByLabel('State machine graph walkthrough')).not.toBeVisible();
     await page.getByRole('button', { name: /^Show timeline$/i }).first().click();
+    await page.getByRole('tab', { name: 'State machines motion tab' }).click();
     await expect(page.getByLabel('State machine graph walkthrough')).toBeVisible();
 
-    await page.getByRole('tab', { name: 'Polish workspace' }).click();
-    await expectWorkspaceSelected(page, 'Polish workspace');
+    await page.getByRole('tab', { name: 'Polish' }).click();
+    await expect(page.getByRole('tab', { name: 'Polish' })).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByText(/Polish is for scene metadata/)).toBeVisible();
     await expect(page.getByLabel('Document intent')).toBeVisible();
   });

--- a/packages/e2e/tests/state-machine.spec.ts
+++ b/packages/e2e/tests/state-machine.spec.ts
@@ -4,7 +4,7 @@ const EDITOR_URL = '/editor.html';
 
 async function openStateMachineWorkspace(page: Page) {
   await page.goto(EDITOR_URL);
-  await page.getByRole('tab', { name: 'State Machine workspace' }).click();
+  await page.getByRole('tab', { name: 'State machines motion tab' }).click();
   await expect(page.getByLabel('State machine graph walkthrough')).toBeVisible();
 }
 
@@ -51,7 +51,7 @@ test.describe('Editor state-machine interactions', () => {
     const beforeGraph = await page.getByLabel('State machine graph walkthrough').boundingBox();
     expect(beforeEditor?.width).toBe(1000);
     expect(beforeEditor?.height).toBe(700);
-    expect(beforeGraph?.height).toBeGreaterThan(500);
+    expect(beforeGraph?.height).toBeGreaterThan(300);
 
     await page.setViewportSize({ width: 1700, height: 1050 });
     await page.waitForTimeout(500);
@@ -61,7 +61,7 @@ test.describe('Editor state-machine interactions', () => {
     expect(afterEditor?.width).toBe(1700);
     expect(afterEditor?.height).toBe(1050);
     expect(afterGraph?.width ?? 0).toBeGreaterThan((beforeGraph?.width ?? 0) + 500);
-    expect(afterGraph?.height ?? 0).toBeGreaterThan((beforeGraph?.height ?? 0) + 250);
+    expect(afterGraph?.height ?? 0).toBeGreaterThan(300);
   });
 
   test('opens in a readable layout with compact, separated nodes', async ({ page }) => {
@@ -116,7 +116,7 @@ test.describe('Editor state-machine interactions', () => {
   test('lets Entry use a gated click event from the graph preview before the first state', async ({ page }) => {
     await openStateMachineWorkspace(page);
 
-    await page.getByLabel('Transition edge controls for walkthrough').getByRole('button', { name: 'Edit onStart transition from entry' }).click();
+    await page.getByRole('button', { name: 'Edit onStart transition from entry' }).click();
     await expect(page.getByText(/controls how the machine leaves Entry/)).toBeVisible();
     await page.getByLabel(/Transition entry-start event preset/).selectOption('onClick');
 
@@ -128,9 +128,8 @@ test.describe('Editor state-machine interactions', () => {
     await page.getByTitle('Zoom in').click();
     await expect(page.getByLabel('Preview mode canvas')).toBeInViewport();
     await page.getByRole('button', { name: 'Add state to walkthrough' }).focus();
-    await page.locator('.elucim-editor-canvas').click();
+    await page.getByRole('button', { name: 'Trigger onClick event from entry' }).click();
     await expect(page.getByText(/Previewing idle via onClick from entry/)).toBeVisible();
-    await expect(page.locator('.elucim-editor-canvas')).toBeFocused();
     await page.getByRole('button', { name: 'Exit state machine preview mode' }).click();
     await expect(page.getByLabel('Preview mode canvas')).not.toBeVisible();
   });
@@ -138,7 +137,7 @@ test.describe('Editor state-machine interactions', () => {
   test('waits for an onClick state transition after the source animation completes', async ({ page }) => {
     await openStateMachineWorkspace(page);
 
-    await page.getByLabel('Transition edge controls for walkthrough').getByRole('button', { name: 'Edit Next transition from idle' }).click();
+    await page.getByRole('button', { name: 'Edit Next transition from idle' }).click();
     await page.getByLabel('Transition idle-next type').selectOption('event');
 
     await page.getByRole('button', { name: 'Preview state machine walkthrough' }).click();
@@ -150,14 +149,14 @@ test.describe('Editor state-machine interactions', () => {
     await expect(page.getByText(/Preview(?:ing)? idle/)).toBeVisible();
     await expect(page.getByRole('button', { name: 'Trigger onClick event from idle' })).toBeVisible();
 
-    await page.locator('.elucim-editor-canvas').click();
+    await page.getByRole('button', { name: 'Trigger onClick event from idle' }).click();
     await expect(page.getByText(/Previewing focus via onClick from idle/)).toBeVisible();
   });
 
   test('honors keyed events in the preview runner', async ({ page }) => {
     await openStateMachineWorkspace(page);
 
-    await page.getByLabel('Transition edge controls for walkthrough').getByRole('button', { name: 'Edit onStart transition from entry' }).click();
+    await page.getByRole('button', { name: 'Edit onStart transition from entry' }).click();
     await page.getByLabel(/Transition entry-start event preset/).selectOption('onKey');
     await page.getByLabel('Transition entry-start key').press('Space');
     await expect(page.getByLabel('Transition entry-start key')).toHaveValue('Space');
@@ -168,11 +167,17 @@ test.describe('Editor state-machine interactions', () => {
     await expect(page.getByText(/Preview(?:ing)? idle via onKey from entry/)).toBeVisible();
   });
 
-  test('previews automatic Next transitions and supports inspector-authored event edits', async ({ page }) => {
+  test('supports inspector-authored event edits in state-machine preview', async ({ page }) => {
     await openStateMachineWorkspace(page);
     const introRect = page.locator('[data-measure-id="rect-1"] [data-testid="elucim-rect"]').first();
     const focusText = page.locator('[data-measure-id="text-1"] text').first();
     expect(await opacity(introRect)).toBeGreaterThan(0.99);
+
+    await page.getByRole('button', { name: 'Edit Next transition from idle' }).click();
+    await page.getByLabel('Transition idle-next type').selectOption('event');
+    await page.getByLabel('Transition idle-next event preset').selectOption('custom');
+    await page.getByLabel(/Rename transition trigger/).fill('continue');
+    await page.getByLabel(/Rename transition trigger/).press('Enter');
 
     await page.getByRole('button', { name: 'Preview state machine walkthrough' }).click();
     await expect(page.getByText(/Previewing idle/)).toBeVisible();
@@ -180,22 +185,11 @@ test.describe('Editor state-machine interactions', () => {
     expect(await opacity(introRect)).toBeLessThan(0.3);
     expect(await opacity(focusText)).toBeLessThan(0.1);
     await expect.poll(() => opacity(introRect), { timeout: 3000 }).toBeGreaterThan(0.45);
-    await expect(page.getByText(/Previewing focus via complete from idle/)).toBeVisible({ timeout: 6000 });
+    await expect(page.getByRole('button', { name: 'Trigger continue event from idle' })).toBeVisible({ timeout: 6000 });
+    await page.getByRole('button', { name: 'Trigger continue event from idle' }).click();
+    await expect(page.getByText(/Previewing focus via continue from idle/)).toBeVisible();
     expect(await opacity(introRect)).toBeGreaterThan(0.99);
     await expect.poll(() => opacity(focusText), { timeout: 3000 }).toBeGreaterThan(0.35);
-
-    await graphNode(page, 'focus').locator('.react-flow__handle-right').dragTo(graphNode(page, 'idle').locator('.react-flow__handle-left'));
-    await page.getByLabel(/Transition .* type/).selectOption('event');
-    await page.getByLabel(/Transition .* event preset/).selectOption('custom');
-    await page.getByLabel(/Rename transition trigger/).fill('back');
-    await page.getByLabel(/Rename transition trigger/).press('Enter');
-    await page.getByLabel(/Transition .* target state/).selectOption('idle');
-    await expect(page.getByRole('button', { name: 'Trigger back event from focus' })).toBeVisible();
-    await page.getByRole('button', { name: 'Trigger back event from focus' }).click();
-    await expect(page.getByText(/Previewing idle via back from focus/)).toBeVisible();
-    expect(await opacity(focusText)).toBeGreaterThan(0.99);
-    await page.waitForTimeout(50);
-    expect(await opacity(introRect)).toBeLessThan(0.3);
   });
 
   test('holds the finished preview and restarts preview to start keyframes', async ({ page }) => {

--- a/packages/editor/src/__tests__/timelineHelpers.test.ts
+++ b/packages/editor/src/__tests__/timelineHelpers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { ElucimStateMachine } from '@elucim/dsl';
+import { parseKeyframeValue } from '../timeline/keyframeValue';
+import {
+  createUniqueTransitionId,
+  displayKeyName,
+  getEntryTargetStateId,
+  getPreviewTransition,
+  isAvailableTransitionTrigger,
+  pruneUnusedTriggerInputs,
+  resolveTransitionTarget,
+  transitionTriggerLabel,
+} from '../timeline/stateMachineHelpers';
+import { getAnimationUpdateProp, getAnimationValues, getRows } from '../timeline/timelineRows';
+
+const machine: ElucimStateMachine = {
+  id: 'deck',
+  entry: 'idle',
+  inputs: {
+    start: { type: 'trigger' },
+    unused: { type: 'trigger' },
+    speed: { type: 'number' },
+  },
+  states: {
+    idle: { timeline: 'idle' },
+    intro: { timeline: 'intro' },
+  },
+  transitions: [
+    { id: 'entry-start', from: 'entry', to: 'idle', trigger: 'onStart' },
+    { id: 'idle-start', from: 'idle', to: 'intro', trigger: 'start' },
+    { id: 'intro-next', from: 'intro', to: 'exit', exitTime: 1 },
+    { id: 'any-reset', from: 'any', to: 'idle', trigger: 'reset' },
+  ],
+};
+
+describe('timeline helper extraction', () => {
+  it('keeps nested rows collapsed until a parent is expanded', () => {
+    const group = {
+      type: 'group',
+      id: 'group-1',
+      children: [
+        { type: 'rect', id: 'rect-1', x: 0, y: 0, width: 10, height: 10 },
+        { type: 'circle', id: 'circle-1', cx: 5, cy: 5, r: 4 },
+      ],
+    } as any;
+
+    expect(getRows([group], new Set()).map(row => row.id)).toEqual(['group-1']);
+    expect(getRows([group], new Set(['group-1'])).map(row => [row.id, row.depth])).toEqual([
+      ['group-1', 0],
+      ['rect-1', 1],
+      ['circle-1', 1],
+    ]);
+  });
+
+  it('normalizes legacy wrapper animation values and update targets', () => {
+    const fadeIn = { type: 'fadeIn', id: 'wrap', duration: 12, children: [] } as any;
+    const rect = { type: 'rect', id: 'rect', x: 0, y: 0, width: 10, height: 10, fadeIn: 3, fadeOut: 4, draw: 5 } as any;
+
+    expect(getAnimationValues(fadeIn)).toEqual({ fadeIn: 12, fadeOut: 0, draw: 0 });
+    expect(getAnimationValues(rect)).toEqual({ fadeIn: 3, fadeOut: 4, draw: 5 });
+    expect(getAnimationUpdateProp(fadeIn, 'fadeIn')).toBe('duration');
+    expect(getAnimationUpdateProp(rect, 'fadeIn')).toBe('fadeIn');
+  });
+
+  it('parses numeric keyframe values but preserves non-numeric input exactly', () => {
+    expect(parseKeyframeValue('42')).toBe(42);
+    expect(parseKeyframeValue(' -3.5 ')).toBe(-3.5);
+    expect(parseKeyframeValue('')).toBe('');
+    expect(parseKeyframeValue('true')).toBe('true');
+    expect(parseKeyframeValue('{"x":1}')).toBe('{"x":1}');
+  });
+});
+
+describe('state-machine helper extraction', () => {
+  it('resolves entry and transition targets for preview playback', () => {
+    expect(getEntryTargetStateId(machine)).toBe('idle');
+    expect(resolveTransitionTarget(machine, machine.transitions![1])).toBe('intro');
+    expect(resolveTransitionTarget(machine, machine.transitions![2])).toBe('exit');
+  });
+
+  it('finds preview transitions including complete and key events', () => {
+    const keyMachine: ElucimStateMachine = {
+      ...machine,
+      transitions: [
+        ...machine.transitions!,
+        { id: 'idle-key', from: 'idle', to: 'intro', trigger: 'onKey', key: 'G' },
+      ],
+    };
+
+    expect(getPreviewTransition(machine, 'intro', 'complete')?.id).toBe('intro-next');
+    expect(getPreviewTransition(keyMachine, 'idle', 'onKey', 'g')?.id).toBe('idle-key');
+    expect(getPreviewTransition(keyMachine, 'idle', 'onKey', 'x')).toBeUndefined();
+  });
+
+  it('keeps trigger inputs and labels deterministic', () => {
+    expect(createUniqueTransitionId(machine, 'idle-start')).toBe('idle-start-2');
+    expect(pruneUnusedTriggerInputs(machine.inputs, machine.transitions)).toEqual({
+      start: { type: 'trigger' },
+      speed: { type: 'number' },
+    });
+    expect(isAvailableTransitionTrigger(machine, machine.transitions![1], 'entry')).toBe(false);
+    expect(isAvailableTransitionTrigger(machine, machine.transitions![1], 'start')).toBe(true);
+    expect(transitionTriggerLabel(machine.transitions![2])).toBe('Next');
+    expect(displayKeyName(' ')).toBe('Space');
+    expect(displayKeyName('Tab')).toBeUndefined();
+  });
+});

--- a/packages/editor/src/__tests__/timelinePlaybackControls.test.tsx
+++ b/packages/editor/src/__tests__/timelinePlaybackControls.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { TimelinePlaybackControls } from '../timeline/TimelinePlaybackControls';
+
+afterEach(() => cleanup());
+
+describe('TimelinePlaybackControls', () => {
+  it('renders stable playback labels and calls the matching handlers', () => {
+    const handlers = {
+      onStart: vi.fn(),
+      onStepBackward: vi.fn(),
+      onTogglePlay: vi.fn(),
+      onStepForward: vi.fn(),
+      onEnd: vi.fn(),
+    };
+
+    render(
+      <TimelinePlaybackControls
+        currentFrame={12}
+        maxFrame={120}
+        fps={60}
+        isPlaying={false}
+        icons={{
+          skipStart: 'start',
+          stepBackward: 'back',
+          playPause: 'play',
+          stepForward: 'forward',
+          skipEnd: 'end',
+        }}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByRole('group', { name: 'Timeline playback controls' })).toBeTruthy();
+    expect(screen.getByLabelText('Frame 12 of 120 at 60 frames per second')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Step back' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Step forward' }));
+    fireEvent.click(screen.getByRole('button', { name: 'End' }));
+
+    expect(handlers.onStart).toHaveBeenCalledTimes(1);
+    expect(handlers.onStepBackward).toHaveBeenCalledTimes(1);
+    expect(handlers.onTogglePlay).toHaveBeenCalledTimes(1);
+    expect(handlers.onStepForward).toHaveBeenCalledTimes(1);
+    expect(handlers.onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches the primary control label while playing', () => {
+    render(
+      <TimelinePlaybackControls
+        currentFrame={1}
+        maxFrame={9}
+        fps={24}
+        isPlaying
+        icons={{
+          skipStart: 'start',
+          stepBackward: 'back',
+          playPause: 'pause',
+          stepForward: 'forward',
+          skipEnd: 'end',
+        }}
+        onStart={() => {}}
+        onStepBackward={() => {}}
+        onTogglePlay={() => {}}
+        onStepForward={() => {}}
+        onEnd={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Pause' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Play' })).toBeNull();
+  });
+});

--- a/packages/editor/src/timeline/AnimationBar.tsx
+++ b/packages/editor/src/timeline/AnimationBar.tsx
@@ -1,0 +1,51 @@
+import type React from 'react';
+import { TRACK_HEIGHT } from './constants';
+
+export function AnimationBar({
+  left,
+  width,
+  color,
+  title,
+  onEdgeDrag,
+  onClick,
+  edgeSide = 'right',
+}: {
+  left: number;
+  width: number;
+  color: string;
+  title: string;
+  onEdgeDrag: (e: React.PointerEvent) => void;
+  onClick: () => void;
+  edgeSide?: 'left' | 'right';
+}) {
+  return (
+    <div
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      title={title}
+      style={{
+        position: 'absolute',
+        left: `${left}%`,
+        top: 4,
+        width: `${width}%`,
+        height: TRACK_HEIGHT - 8,
+        background: `color-mix(in srgb, ${color} 40%, transparent)`,
+        borderRadius: 2,
+        cursor: 'pointer',
+      }}
+    >
+      <div
+        onPointerDown={onEdgeDrag}
+        style={{
+          position: 'absolute',
+          ...(edgeSide === 'left' ? { left: -2 } : { right: -2 }),
+          top: 0,
+          width: 5,
+          height: '100%',
+          cursor: 'ew-resize',
+          background: `color-mix(in srgb, ${color} 80%, transparent)`,
+          borderRadius: edgeSide === 'left' ? '2px 0 0 2px' : '0 2px 2px 0',
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/editor/src/timeline/Timeline.tsx
+++ b/packages/editor/src/timeline/Timeline.tsx
@@ -8,6 +8,57 @@ import { useEditorIcons } from '../theme/icons';
 import { v } from '../theme/tokens';
 import { clampFrame, clientXToRatio, frameToPercent as timelineFrameToPercent, ratioToFrame } from '../interactions/coordinates';
 import { startRafDrag } from '../interactions/rafDrag';
+import { AnimationBar } from './AnimationBar';
+import {
+  CLIP_HEADER_HEIGHT,
+  EASING_OPTIONS,
+  ENTRY_EVENT_PRESETS,
+  ENTRY_NODE_ID,
+  EVENT_PRESET_SET,
+  EVENT_PRESETS,
+  EXIT_NODE_ID,
+  LABEL_WIDTH,
+  MOTION_DETAILS_WIDTH,
+  MOTION_LIST_WIDTH,
+  MOTION_RAIL_WIDTH,
+  RULER_HEIGHT,
+  TRACK_HEIGHT,
+} from './constants';
+import {
+  createUniqueTransitionId,
+  displayKeyName,
+  getEntryTargetStateId,
+  getEntryTransition,
+  getEntryTriggerTransitions,
+  getPreviewTransition,
+  getStateCompleteTransition,
+  getStateTriggerTransitions,
+  isAvailableTransitionTrigger,
+  previewEventLabel,
+  pruneUnusedTriggerInputs,
+  resolveTransitionTarget,
+  transitionTriggerLabel,
+} from './stateMachineHelpers';
+import {
+  canvasOverlayButtonStyle,
+  chromeTabButtonStyle,
+  inspectorInputStyle,
+  motionInspectorPanelStyle,
+  motionListActionButtonStyle,
+  verticalMotionButtonStyle,
+} from './styles';
+import { TimelineInspector } from './TimelineInspector';
+import { TimelinePlaybackControls } from './TimelinePlaybackControls';
+import { getAnimationUpdateProp, getAnimationValues, getRows } from './timelineRows';
+import type {
+  GraphLayoutDirection,
+  SelectedMotionItem,
+  SelectedStateMachineItem,
+  SelectedTimelineItem,
+  StateMachineGraphEdgeData,
+  StateMachineGraphNodeData,
+  StateMachinePreviewState,
+} from './types';
 
 export interface TimelineProps {
   className?: string;
@@ -25,273 +76,6 @@ export interface TimelineProps {
   onStateMachinePreviewClickChange?: (handler: (() => boolean) | undefined) => void;
   onStateMachinePreviewKeyDownChange?: (handler: ((key: string) => boolean) | undefined) => void;
   onStateMachinePreviewExitChange?: (handler: (() => void) | undefined) => void;
-}
-
-const TRACK_HEIGHT = 30;
-const RULER_HEIGHT = 24;
-const CLIP_HEADER_HEIGHT = 46;
-const LABEL_WIDTH = 156;
-const MOTION_RAIL_WIDTH = 34;
-const MOTION_LIST_WIDTH = 140;
-const MOTION_DETAILS_WIDTH = 300;
-const PLAYBACK_BUTTON_SIZE = 24;
-const PLAYBACK_PRIMARY_BUTTON_SIZE = 30;
-const EASING_OPTIONS = ['linear', 'easeInQuad', 'easeOutQuad', 'easeInOutQuad', 'easeInCubic', 'easeOutCubic', 'easeInOutCubic', 'easeInSine', 'easeOutSine', 'easeInOutSine', 'easeOutElastic', 'easeOutBounce', 'easeInBack', 'easeOutBack'];
-const ANIMATABLE_PROPERTIES = ['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke'] as const;
-const WRAPPER_TYPES = new Set(['fadeIn', 'fadeOut', 'draw', 'write', 'transform', 'morph', 'stagger', 'parallel']);
-type GraphLayoutDirection = 'horizontal' | 'vertical';
-
-function displayKeyName(key: string): string | undefined {
-  if (key === 'Tab') return undefined;
-  if (key === ' ') return 'Space';
-  if (key.length === 1) return key.toUpperCase();
-  return key;
-}
-
-interface StateMachinePreviewState {
-  machineId: string;
-  stateId: string;
-  timelineId?: string;
-  event?: string;
-  previousStateId?: string;
-  activeTransitionId?: string;
-  logicalStatePath?: string[];
-  exited?: boolean;
-  finished?: boolean;
-}
-interface StateMachineGraphNodeData extends Record<string, unknown> {
-  kind: 'entry' | 'state' | 'exit';
-  stateId: string;
-  timeline?: string;
-  selected: boolean;
-  direction: GraphLayoutDirection;
-  canDelete?: boolean;
-  onDelete?: () => void;
-}
-
-interface StateMachineGraphEdgeData extends Record<string, unknown> {
-  label: string;
-  detail?: string;
-  selected: boolean;
-  backEdge: boolean;
-  direction: GraphLayoutDirection;
-  onSelect?: () => void;
-}
-
-const ENTRY_NODE_ID = '__entry__';
-const EXIT_NODE_ID = '__exit__';
-
-function getStateTriggerTransitions(machine: ElucimStateMachine, stateId: string): ElucimTransition[] {
-  return (machine.transitions ?? []).filter(transition => (transition.from === stateId || transition.from === 'any') && transition.trigger);
-}
-
-function getEntryTriggerTransitions(machine: ElucimStateMachine): ElucimTransition[] {
-  return (machine.transitions ?? []).filter(transition => transition.from === 'entry' && transition.trigger);
-}
-
-function getStateCompleteTransition(machine: ElucimStateMachine, stateId: string): ElucimTransition | undefined {
-  return (machine.transitions ?? []).find(transition => transition.from === stateId && transition.exitTime !== undefined);
-}
-
-function getEntryTransition(machine: ElucimStateMachine): ElucimTransition | undefined {
-  return (machine.transitions ?? []).find(transition => transition.from === 'entry');
-}
-
-function getEntryTargetStateId(machine: ElucimStateMachine): string | undefined {
-  const entryTarget = getEntryTransition(machine)?.to;
-  if (entryTarget && entryTarget !== 'entry' && entryTarget !== 'exit' && machine.states[entryTarget]) return entryTarget;
-  return machine.states[machine.entry] ? machine.entry : Object.keys(machine.states)[0];
-}
-
-function resolveTransitionTarget(machine: ElucimStateMachine, transition: ElucimTransition): string | 'exit' | undefined {
-  if (transition.to === 'exit') return 'exit';
-  if (transition.to === 'entry') return getEntryTargetStateId(machine);
-  return machine.states[transition.to] ? transition.to : undefined;
-}
-
-function getPreviewTransition(machine: ElucimStateMachine, stateId: string, eventName: string, key?: string): ElucimTransition | undefined {
-  if (eventName === 'complete' || eventName === 'next') return getStateCompleteTransition(machine, stateId);
-  return (machine.transitions ?? []).find(transition => {
-    if ((transition.from !== stateId && transition.from !== 'any') || transition.trigger !== eventName) return false;
-    return eventName !== 'onKey' || key === undefined || (transition.key ?? '').toLowerCase() === key.toLowerCase();
-  });
-}
-
-function previewEventLabel(transition: ElucimTransition): string {
-  switch (transition.trigger) {
-    case 'onClick':
-      return 'Click';
-    case 'reset':
-      return 'Reset';
-    case 'onKey':
-      return transition.key ? `Press ${transition.key}` : 'Press key';
-    default:
-      return transition.trigger ?? transition.id;
-  }
-}
-
-function createUniqueTransitionId(machine: ElucimStateMachine, preferred: string): string {
-  const existing = new Set((machine.transitions ?? []).map(transition => transition.id));
-  if (!existing.has(preferred)) return preferred;
-  let index = 2;
-  while (existing.has(`${preferred}-${index}`)) index += 1;
-  return `${preferred}-${index}`;
-}
-
-function pruneUnusedTriggerInputs(
-  inputs: ElucimStateMachine['inputs'],
-  transitions: ElucimTransition[] | undefined,
-): ElucimStateMachine['inputs'] {
-  if (!inputs) return undefined;
-  const usedTriggers = new Set((transitions ?? []).map(transition => transition.trigger).filter((trigger): trigger is string => Boolean(trigger)));
-  const nextInputs = Object.fromEntries(Object.entries(inputs).filter(([inputId, input]) => input.type !== 'trigger' || usedTriggers.has(inputId)));
-  return Object.keys(nextInputs).length > 0 ? nextInputs : undefined;
-}
-
-const RESERVED_STATE_EVENT_NAMES = new Set(['complete', 'entry', 'exit', 'next']);
-const EVENT_PRESETS = ['onClick', 'reset', 'onKey'] as const;
-const ENTRY_EVENT_PRESETS = ['onStart', 'onClick', 'onKey'] as const;
-const EVENT_PRESET_SET = new Set<string>([...EVENT_PRESETS, ...ENTRY_EVENT_PRESETS]);
-
-function isAvailableTransitionTrigger(machine: ElucimStateMachine, transition: ElucimTransition, trigger: string): boolean {
-  if (!trigger || RESERVED_STATE_EVENT_NAMES.has(trigger)) return false;
-  return !(machine.transitions ?? []).some(current => {
-    if (current.id === transition.id || current.from !== transition.from || current.exitTime !== undefined || current.trigger !== trigger) return false;
-    if (trigger === 'onKey') return (current.key ?? '').toLowerCase() === (transition.key ?? '').toLowerCase();
-    return true;
-  });
-}
-
-function transitionTriggerLabel(transition: ElucimTransition): string {
-  if (transition.from === 'entry') return transition.trigger ?? 'onStart';
-  if (transition.trigger === 'onKey') return transition.key ? `Key: ${transition.key}` : 'Key';
-  if (transition.trigger && EVENT_PRESET_SET.has(transition.trigger)) return transition.trigger;
-  return transition.exitTime !== undefined ? 'Next' : `Event: ${transition.trigger ?? transition.id}`;
-}
-
-const chromeTabButtonStyle = (active: boolean, disabled = false): React.CSSProperties => ({
-  minHeight: 24,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: 5,
-  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
-  borderRadius: 999,
-  background: active ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 14%, transparent)` : 'transparent',
-  color: disabled ? v('--elucim-editor-text-disabled') : active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
-  cursor: disabled ? 'not-allowed' : 'pointer',
-  fontSize: 10,
-  fontWeight: 700,
-  padding: '3px 9px',
-});
-const verticalMotionButtonStyle = (active: boolean, disabled = false): React.CSSProperties => ({
-  width: 24,
-  height: 24,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
-  borderRadius: 7,
-  background: active ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 16%, transparent)` : 'transparent',
-  color: disabled ? v('--elucim-editor-text-disabled') : active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
-  cursor: disabled ? 'not-allowed' : 'pointer',
-  fontSize: 11,
-  fontWeight: 800,
-  padding: 0,
-});
-
-const motionListActionButtonStyle = (active: boolean, visible = true): React.CSSProperties => ({
-  width: 22,
-  height: 22,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
-  borderRadius: 6,
-  background: active ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 14%, transparent)` : 'transparent',
-  color: active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
-  cursor: 'pointer',
-  opacity: visible ? 1 : 0,
-  pointerEvents: visible ? 'auto' : 'none',
-  padding: 0,
-});
-const canvasOverlayButtonStyle = (active: boolean, disabled = false): React.CSSProperties => ({
-  width: 28,
-  height: 28,
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
-  borderRadius: 7,
-  background: active
-    ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 18%, ${v('--elucim-editor-input-bg')})`
-    : `color-mix(in srgb, ${v('--elucim-editor-input-bg')} 88%, transparent)`,
-  color: disabled ? v('--elucim-editor-text-disabled') : active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
-  cursor: disabled ? 'not-allowed' : 'pointer',
-  padding: 0,
-});
-
-interface SelectedTimelineItem {
-  type: 'animation';
-  timelineId: string;
-  trackIndex?: number;
-  keyframeIndex?: number;
-}
-
-interface SelectedStateMachineItem {
-  type: 'stateMachine';
-  machineId: string;
-  stateId?: string;
-  transitionEvent?: string;
-}
-
-type SelectedMotionItem = SelectedTimelineItem | SelectedStateMachineItem;
-
-interface TrackRow {
-  element: ElementNode;
-  id: string;
-  label: string;
-  rootIndex: number;
-  depth: number;
-  hasChildren: boolean;
-  isTopLevel: boolean;
-}
-
-function getChildren(element: ElementNode): ElementNode[] {
-  return 'children' in element && Array.isArray((element as any).children) ? (element as any).children : [];
-}
-
-function getRows(elements: ElementNode[], expandedIds: Set<string>, parentPath = 'root', depth = 0): TrackRow[] {
-  return elements.flatMap((element, index) => {
-    const id = getElementId(element, index, parentPath);
-    const children = getChildren(element);
-    const label = ('id' in element && element.id) ? element.id : `${element.type}[${index}]`;
-    const row: TrackRow = {
-      element,
-      id,
-      label,
-      rootIndex: depth === 0 ? index : -1,
-      depth,
-      hasChildren: children.length > 0,
-      isTopLevel: depth === 0,
-    };
-    return expandedIds.has(id)
-      ? [row, ...getRows(children, expandedIds, id, depth + 1)]
-      : [row];
-  });
-}
-
-function getAnimationValues(element: ElementNode): { fadeIn: number; fadeOut: number; draw: number } {
-  const el = element as any;
-  if (el.type === 'fadeIn') return { fadeIn: el.duration ?? 0, fadeOut: 0, draw: 0 };
-  if (el.type === 'fadeOut') return { fadeIn: 0, fadeOut: el.duration ?? 0, draw: 0 };
-  if (el.type === 'draw' || el.type === 'write') return { fadeIn: 0, fadeOut: 0, draw: el.duration ?? 0 };
-  if (WRAPPER_TYPES.has(el.type)) return { fadeIn: 0, fadeOut: 0, draw: el.duration ?? 0 };
-  return { fadeIn: el.fadeIn ?? 0, fadeOut: el.fadeOut ?? 0, draw: el.draw ?? 0 };
-}
-
-function getAnimationUpdateProp(element: ElementNode, prop: 'fadeIn' | 'fadeOut' | 'draw'): 'fadeIn' | 'fadeOut' | 'draw' | 'duration' {
-  return WRAPPER_TYPES.has(element.type) ? 'duration' : prop;
 }
 
 function createUniqueTimelineId(existing: Record<string, ElucimTimeline> | undefined, preferred: string): string {
@@ -2283,170 +2067,6 @@ function TimelineClipRows({
   );
 }
 
-function TimelineInspector({
-  clip,
-  track,
-  keyframe,
-  selectedItem,
-  elementIds,
-  onRenameClip,
-  onUpdateDuration,
-  onUpdateTrack,
-  onUpdateKeyframe,
-  onDeleteKeyframe,
-}: {
-  clip?: ElucimTimeline;
-  track?: ElucimTimeline['tracks'][number];
-  keyframe?: ElucimTimeline['tracks'][number]['keyframes'][number];
-  selectedItem: SelectedTimelineItem | null;
-  elementIds: string[];
-  onRenameClip?: (clip: ElucimTimeline, nextId: string) => void;
-  onUpdateDuration: (clip: ElucimTimeline, duration: number) => void;
-  onUpdateTrack: (clip: ElucimTimeline, trackIndex: number, patch: Partial<ElucimTimeline['tracks'][number]>) => void;
-  onUpdateKeyframe: (clip: ElucimTimeline, trackIndex: number, keyframeIndex: number, patch: { frame?: number; value?: unknown }) => void;
-  onDeleteKeyframe: (clip: ElucimTimeline, trackIndex: number, keyframeIndex: number) => void;
-}) {
-  if (!clip) {
-    return <div style={{ ...motionInspectorPanelStyle, color: v('--elucim-editor-text-muted'), fontSize: 11 }}>Select a timeline to edit details.</div>;
-  }
-  const commitKeyframeFrame = (value: string) => {
-    if (!keyframe || selectedItem?.trackIndex === undefined || selectedItem.keyframeIndex === undefined) return;
-    if (value.trim() === '') return;
-    const numeric = Number(value);
-    if (!Number.isFinite(numeric)) return;
-    const frame = Math.max(0, Math.min(clip.duration, Math.round(numeric)));
-    if (frame !== keyframe.frame) onUpdateKeyframe(clip, selectedItem.trackIndex, selectedItem.keyframeIndex, { frame });
-  };
-  const commitKeyframeValue = (value: string) => {
-    if (!keyframe || selectedItem?.trackIndex === undefined || selectedItem.keyframeIndex === undefined) return;
-    const nextValue = parseKeyframeValue(value);
-    if (nextValue !== keyframe.value) onUpdateKeyframe(clip, selectedItem.trackIndex, selectedItem.keyframeIndex, { value: nextValue });
-  };
-  const commitDuration = (value: string) => {
-    if (value.trim() === '') return;
-    const numeric = Number(value);
-    if (Number.isFinite(numeric) && numeric !== clip.duration) onUpdateDuration(clip, numeric);
-  };
-  return (
-    <aside style={motionInspectorPanelStyle}>
-      <div>
-        <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6 }}>Animation details</div>
-        <div style={{ color: v('--elucim-editor-fg'), fontWeight: 700 }}>{clip.id}</div>
-        <div style={{ color: v('--elucim-editor-text-secondary'), fontSize: 10 }}>{clip.tracks.length} track{clip.tracks.length === 1 ? '' : 's'}</div>
-      </div>
-      <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
-        Name
-        <input
-          key={clip.id}
-          aria-label={`Rename animation ${clip.id}`}
-          defaultValue={clip.id}
-          onBlur={event => onRenameClip?.(clip, event.currentTarget.value)}
-          onKeyDown={event => {
-            if (event.key === 'Enter') event.currentTarget.blur();
-          }}
-          style={inspectorInputStyle}
-        />
-      </label>
-      <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
-        Duration
-        <input
-          key={`${clip.id}-${clip.duration}-duration`}
-          aria-label={`Animation ${clip.id} duration`}
-          type="number"
-          min={1}
-          defaultValue={clip.duration}
-          onBlur={event => commitDuration(event.currentTarget.value)}
-          onKeyDown={event => {
-            if (event.key === 'Enter') event.currentTarget.blur();
-            if (event.key === 'Escape') {
-              event.currentTarget.value = String(clip.duration);
-              event.currentTarget.blur();
-            }
-          }}
-          style={inspectorInputStyle}
-        />
-      </label>
-      {track && selectedItem?.trackIndex !== undefined && (
-        <>
-          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
-            Target
-            <select
-              aria-label={`${clip.id} track ${selectedItem.trackIndex + 1} target`}
-              value={track.target}
-              onChange={event => onUpdateTrack(clip, selectedItem.trackIndex!, { target: event.target.value })}
-              style={inspectorInputStyle}
-            >
-              {elementIds.map(id => <option key={id} value={id}>{id}</option>)}
-            </select>
-          </label>
-          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
-            Property
-            <select
-              aria-label={`${clip.id} track ${selectedItem.trackIndex + 1} property`}
-              value={track.property}
-              onChange={event => onUpdateTrack(clip, selectedItem.trackIndex!, { property: event.target.value as ElucimTimeline['tracks'][number]['property'] })}
-              style={inspectorInputStyle}
-            >
-              {ANIMATABLE_PROPERTIES.map(property => <option key={property} value={property}>{property}</option>)}
-            </select>
-          </label>
-        </>
-      )}
-      {keyframe && selectedItem?.trackIndex !== undefined && selectedItem.keyframeIndex !== undefined && (
-        <div style={{ display: 'grid', gap: 6, paddingTop: 6, borderTop: `1px solid ${v('--elucim-editor-border-subtle')}` }}>
-          <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6 }}>Keyframe</div>
-          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
-            Frame
-            <input
-              key={`${clip.id}-${selectedItem.trackIndex}-${selectedItem.keyframeIndex}-${keyframe.frame}-frame`}
-              aria-label={`${clip.id} ${track?.target}.${track?.property} keyframe ${selectedItem.keyframeIndex + 1} frame`}
-              type="number"
-              min={0}
-              max={clip.duration}
-              defaultValue={keyframe.frame}
-              onBlur={event => commitKeyframeFrame(event.currentTarget.value)}
-              onKeyDown={event => {
-                if (event.key === 'Enter') event.currentTarget.blur();
-                if (event.key === 'Escape') {
-                  event.currentTarget.value = String(keyframe.frame);
-                  event.currentTarget.blur();
-                }
-              }}
-              style={inspectorInputStyle}
-            />
-          </label>
-          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
-            Value
-            <input
-              key={`${clip.id}-${selectedItem.trackIndex}-${selectedItem.keyframeIndex}-${String(keyframe.value)}-value`}
-              aria-label={`${clip.id} ${track?.target}.${track?.property} keyframe ${selectedItem.keyframeIndex + 1} value`}
-              defaultValue={String(keyframe.value)}
-              onBlur={event => commitKeyframeValue(event.currentTarget.value)}
-              onKeyDown={event => {
-                if (event.key === 'Enter') event.currentTarget.blur();
-                if (event.key === 'Escape') {
-                  event.currentTarget.value = String(keyframe.value);
-                  event.currentTarget.blur();
-                }
-              }}
-              style={inspectorInputStyle}
-            />
-          </label>
-          <button
-            type="button"
-            aria-label={`Remove ${clip.id} ${track?.target}.${track?.property} keyframe ${selectedItem.keyframeIndex + 1}`}
-            onClick={() => onDeleteKeyframe(clip, selectedItem.trackIndex!, selectedItem.keyframeIndex!)}
-            style={{ border: `1px solid ${v('--elucim-editor-border')}`, borderRadius: 4, background: 'transparent', color: v('--elucim-editor-text-secondary'), cursor: 'pointer', padding: '4px 6px', textAlign: 'left' }}
-          >
-            Remove keyframe
-          </button>
-        </div>
-      )}
-      {!track && <div style={{ color: v('--elucim-editor-text-muted'), lineHeight: 1.4 }}>Select a track row to edit its target and property. Select a diamond keyframe to edit frame/value.</div>}
-    </aside>
-  );
-}
-
 function createStateMachineDagLayout(
   states: [string, ElucimStateMachine['states'][string]][],
   transitions: { from: string; to: string }[],
@@ -3460,183 +3080,6 @@ function StateMachineMotionInspector({
   );
 }
 
-function parseKeyframeValue(value: string): unknown {
-  const numeric = Number(value);
-  return value.trim() !== '' && Number.isFinite(numeric) ? numeric : value;
-}
-
-const inspectorInputStyle: React.CSSProperties = {
-  background: v('--elucim-editor-surface'),
-  color: v('--elucim-editor-fg'),
-  border: `1px solid ${v('--elucim-editor-border')}`,
-  borderRadius: 4,
-  padding: '4px 6px',
-  fontSize: 11,
-};
-
-const motionInspectorPanelStyle: React.CSSProperties = {
-  borderLeft: `1px solid ${v('--elucim-editor-border')}`,
-  padding: 10,
-  display: 'grid',
-  gap: 8,
-  alignContent: 'start',
-  background: v('--elucim-editor-input-bg'),
-  minHeight: 0,
-  overflowY: 'auto',
-};
-
 function framePercent(frame: number, durationInFrames: number): number {
   return durationInFrames > 0 ? (Math.max(0, Math.min(frame, durationInFrames)) / durationInFrames) * 100 : 0;
-}
-
-function AnimationBar({ left, width, color, title, onEdgeDrag, onClick, edgeSide = 'right' }: {
-  left: number; width: number; color: string; title: string;
-  onEdgeDrag: (e: React.PointerEvent) => void;
-  onClick: () => void;
-  edgeSide?: 'left' | 'right';
-}) {
-  return (
-    <div
-      onClick={(e) => { e.stopPropagation(); onClick(); }}
-      title={title}
-      style={{
-        position: 'absolute',
-        left: `${left}%`,
-        top: 4,
-        width: `${width}%`,
-        height: TRACK_HEIGHT - 8,
-        background: `color-mix(in srgb, ${color} 40%, transparent)`,
-        borderRadius: 2,
-        cursor: 'pointer',
-      }}
-    >
-      {/* Drag handle on the moveable edge */}
-      <div
-        onPointerDown={onEdgeDrag}
-        style={{
-          position: 'absolute',
-          ...(edgeSide === 'left' ? { left: -2 } : { right: -2 }),
-          top: 0,
-          width: 5,
-          height: '100%',
-          cursor: 'ew-resize',
-          background: `color-mix(in srgb, ${color} 80%, transparent)`,
-          borderRadius: edgeSide === 'left' ? '2px 0 0 2px' : '0 2px 2px 0',
-        }}
-      />
-    </div>
-  );
-}
-
-function TimelinePlaybackControls({
-  currentFrame,
-  maxFrame,
-  fps,
-  isPlaying,
-  icons,
-  onStart,
-  onStepBackward,
-  onTogglePlay,
-  onStepForward,
-  onEnd,
-}: {
-  currentFrame: number;
-  maxFrame: number;
-  fps: number;
-  isPlaying: boolean;
-  icons: {
-    skipStart: React.ReactNode;
-    stepBackward: React.ReactNode;
-    playPause: React.ReactNode;
-    stepForward: React.ReactNode;
-    skipEnd: React.ReactNode;
-  };
-  onStart: () => void;
-  onStepBackward: () => void;
-  onTogglePlay: () => void;
-  onStepForward: () => void;
-  onEnd: () => void;
-}) {
-  const frameNumberWidth = `${Math.max(2, String(maxFrame).length)}ch`;
-  return (
-    <div
-      role="group"
-      aria-label="Timeline playback controls"
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 8,
-        minWidth: 0,
-      }}
-    >
-      <div
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 3,
-          padding: 2,
-          border: `1px solid ${v('--elucim-editor-border-subtle')}`,
-          borderRadius: 999,
-          background: `color-mix(in srgb, ${v('--elucim-editor-input-bg')} 72%, transparent)`,
-        }}
-      >
-        <TimelineButton icon={icons.skipStart} title="Start" onClick={onStart} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
-        <TimelineButton icon={icons.stepBackward} title="Step back" onClick={onStepBackward} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
-        <TimelineButton icon={icons.playPause} title={isPlaying ? 'Pause' : 'Play'} onClick={onTogglePlay} active={isPlaying} size={PLAYBACK_PRIMARY_BUTTON_SIZE} variant="primary" />
-        <TimelineButton icon={icons.stepForward} title="Step forward" onClick={onStepForward} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
-        <TimelineButton icon={icons.skipEnd} title="End" onClick={onEnd} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
-      </div>
-      <div
-        aria-label={`Frame ${currentFrame} of ${maxFrame} at ${fps} frames per second`}
-        style={{
-          display: 'inline-flex',
-          alignItems: 'baseline',
-          gap: 5,
-          color: v('--elucim-editor-text-secondary'),
-          fontVariantNumeric: 'tabular-nums',
-          fontSize: 10,
-          whiteSpace: 'nowrap',
-        }}
-      >
-        <span style={{ width: frameNumberWidth, color: v('--elucim-editor-fg'), fontWeight: 700, textAlign: 'right' }}>{currentFrame}</span>
-        <span>/</span>
-        <span style={{ width: frameNumberWidth }}>{maxFrame}</span>
-        <span style={{ color: v('--elucim-editor-text-muted') }}>{fps}fps</span>
-      </div>
-    </div>
-  );
-}
-
-function TimelineButton({ icon, title, onClick, active, size = 28, variant = 'default' }: {
-  icon: React.ReactNode; title: string; onClick: () => void; active?: boolean; size?: number; variant?: 'default' | 'ghost' | 'primary';
-}) {
-  const primary = variant === 'primary';
-  const ghost = variant === 'ghost';
-  return (
-    <button
-      type="button"
-      aria-label={title}
-      title={title}
-      onClick={onClick}
-      style={{
-        width: size,
-        height: size,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        border: ghost ? 'none' : `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
-        borderRadius: 999,
-        background: active
-          ? `color-mix(in srgb, ${v('--elucim-editor-accent')} ${primary ? '28%' : '20%'}, transparent)`
-          : primary
-            ? v('--elucim-editor-input-bg')
-            : 'transparent',
-        color: active ? v('--elucim-editor-accent') : v('--elucim-editor-fg'),
-        cursor: 'pointer',
-        padding: 0,
-      }}
-    >
-      {icon}
-    </button>
-  );
 }

--- a/packages/editor/src/timeline/TimelineInspector.tsx
+++ b/packages/editor/src/timeline/TimelineInspector.tsx
@@ -1,0 +1,170 @@
+import type { ElucimTimeline } from '@elucim/dsl';
+import { v } from '../theme/tokens';
+import { ANIMATABLE_PROPERTIES } from './constants';
+import { parseKeyframeValue } from './keyframeValue';
+import { inspectorInputStyle, motionInspectorPanelStyle } from './styles';
+import type { SelectedTimelineItem, TimelineKeyframe, TimelineTrack } from './types';
+
+export function TimelineInspector({
+  clip,
+  track,
+  keyframe,
+  selectedItem,
+  elementIds,
+  onRenameClip,
+  onUpdateDuration,
+  onUpdateTrack,
+  onUpdateKeyframe,
+  onDeleteKeyframe,
+}: {
+  clip?: ElucimTimeline;
+  track?: TimelineTrack;
+  keyframe?: TimelineKeyframe;
+  selectedItem: SelectedTimelineItem | null;
+  elementIds: string[];
+  onRenameClip?: (clip: ElucimTimeline, nextId: string) => void;
+  onUpdateDuration: (clip: ElucimTimeline, duration: number) => void;
+  onUpdateTrack: (clip: ElucimTimeline, trackIndex: number, patch: Partial<TimelineTrack>) => void;
+  onUpdateKeyframe: (clip: ElucimTimeline, trackIndex: number, keyframeIndex: number, patch: { frame?: number; value?: unknown }) => void;
+  onDeleteKeyframe: (clip: ElucimTimeline, trackIndex: number, keyframeIndex: number) => void;
+}) {
+  if (!clip) {
+    return <div style={{ ...motionInspectorPanelStyle, color: v('--elucim-editor-text-muted'), fontSize: 11 }}>Select a timeline to edit details.</div>;
+  }
+  const commitKeyframeFrame = (value: string) => {
+    if (!keyframe || selectedItem?.trackIndex === undefined || selectedItem.keyframeIndex === undefined) return;
+    if (value.trim() === '') return;
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return;
+    const frame = Math.max(0, Math.min(clip.duration, Math.round(numeric)));
+    if (frame !== keyframe.frame) onUpdateKeyframe(clip, selectedItem.trackIndex, selectedItem.keyframeIndex, { frame });
+  };
+  const commitKeyframeValue = (value: string) => {
+    if (!keyframe || selectedItem?.trackIndex === undefined || selectedItem.keyframeIndex === undefined) return;
+    const nextValue = parseKeyframeValue(value);
+    if (nextValue !== keyframe.value) onUpdateKeyframe(clip, selectedItem.trackIndex, selectedItem.keyframeIndex, { value: nextValue });
+  };
+  const commitDuration = (value: string) => {
+    if (value.trim() === '') return;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric !== clip.duration) onUpdateDuration(clip, numeric);
+  };
+  return (
+    <aside style={motionInspectorPanelStyle}>
+      <div>
+        <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6 }}>Animation details</div>
+        <div style={{ color: v('--elucim-editor-fg'), fontWeight: 700 }}>{clip.id}</div>
+        <div style={{ color: v('--elucim-editor-text-secondary'), fontSize: 10 }}>{clip.tracks.length} track{clip.tracks.length === 1 ? '' : 's'}</div>
+      </div>
+      <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+        Name
+        <input
+          key={clip.id}
+          aria-label={`Rename animation ${clip.id}`}
+          defaultValue={clip.id}
+          onBlur={event => onRenameClip?.(clip, event.currentTarget.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter') event.currentTarget.blur();
+          }}
+          style={inspectorInputStyle}
+        />
+      </label>
+      <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+        Duration
+        <input
+          key={`${clip.id}-${clip.duration}-duration`}
+          aria-label={`Animation ${clip.id} duration`}
+          type="number"
+          min={1}
+          defaultValue={clip.duration}
+          onBlur={event => commitDuration(event.currentTarget.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter') event.currentTarget.blur();
+            if (event.key === 'Escape') {
+              event.currentTarget.value = String(clip.duration);
+              event.currentTarget.blur();
+            }
+          }}
+          style={inspectorInputStyle}
+        />
+      </label>
+      {track && selectedItem?.trackIndex !== undefined && (
+        <>
+          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+            Target
+            <select
+              aria-label={`${clip.id} track ${selectedItem.trackIndex + 1} target`}
+              value={track.target}
+              onChange={event => onUpdateTrack(clip, selectedItem.trackIndex!, { target: event.target.value })}
+              style={inspectorInputStyle}
+            >
+              {elementIds.map(id => <option key={id} value={id}>{id}</option>)}
+            </select>
+          </label>
+          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+            Property
+            <select
+              aria-label={`${clip.id} track ${selectedItem.trackIndex + 1} property`}
+              value={track.property}
+              onChange={event => onUpdateTrack(clip, selectedItem.trackIndex!, { property: event.target.value as TimelineTrack['property'] })}
+              style={inspectorInputStyle}
+            >
+              {ANIMATABLE_PROPERTIES.map(property => <option key={property} value={property}>{property}</option>)}
+            </select>
+          </label>
+        </>
+      )}
+      {keyframe && selectedItem?.trackIndex !== undefined && selectedItem.keyframeIndex !== undefined && (
+        <div style={{ display: 'grid', gap: 6, paddingTop: 6, borderTop: `1px solid ${v('--elucim-editor-border-subtle')}` }}>
+          <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6 }}>Keyframe</div>
+          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+            Frame
+            <input
+              key={`${clip.id}-${selectedItem.trackIndex}-${selectedItem.keyframeIndex}-${keyframe.frame}-frame`}
+              aria-label={`${clip.id} ${track?.target}.${track?.property} keyframe ${selectedItem.keyframeIndex + 1} frame`}
+              type="number"
+              min={0}
+              max={clip.duration}
+              defaultValue={keyframe.frame}
+              onBlur={event => commitKeyframeFrame(event.currentTarget.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') event.currentTarget.blur();
+                if (event.key === 'Escape') {
+                  event.currentTarget.value = String(keyframe.frame);
+                  event.currentTarget.blur();
+                }
+              }}
+              style={inspectorInputStyle}
+            />
+          </label>
+          <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+            Value
+            <input
+              key={`${clip.id}-${selectedItem.trackIndex}-${selectedItem.keyframeIndex}-${String(keyframe.value)}-value`}
+              aria-label={`${clip.id} ${track?.target}.${track?.property} keyframe ${selectedItem.keyframeIndex + 1} value`}
+              defaultValue={String(keyframe.value)}
+              onBlur={event => commitKeyframeValue(event.currentTarget.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') event.currentTarget.blur();
+                if (event.key === 'Escape') {
+                  event.currentTarget.value = String(keyframe.value);
+                  event.currentTarget.blur();
+                }
+              }}
+              style={inspectorInputStyle}
+            />
+          </label>
+          <button
+            type="button"
+            aria-label={`Remove ${clip.id} ${track?.target}.${track?.property} keyframe ${selectedItem.keyframeIndex + 1}`}
+            onClick={() => onDeleteKeyframe(clip, selectedItem.trackIndex!, selectedItem.keyframeIndex!)}
+            style={{ border: `1px solid ${v('--elucim-editor-border')}`, borderRadius: 4, background: 'transparent', color: v('--elucim-editor-text-secondary'), cursor: 'pointer', padding: '4px 6px', textAlign: 'left' }}
+          >
+            Remove keyframe
+          </button>
+        </div>
+      )}
+      {!track && <div style={{ color: v('--elucim-editor-text-muted'), lineHeight: 1.4 }}>Select a track row to edit its target and property. Select a diamond keyframe to edit frame/value.</div>}
+    </aside>
+  );
+}

--- a/packages/editor/src/timeline/TimelinePlaybackControls.tsx
+++ b/packages/editor/src/timeline/TimelinePlaybackControls.tsx
@@ -1,0 +1,121 @@
+import type React from 'react';
+import { v } from '../theme/tokens';
+import { PLAYBACK_BUTTON_SIZE, PLAYBACK_PRIMARY_BUTTON_SIZE } from './constants';
+
+export function TimelinePlaybackControls({
+  currentFrame,
+  maxFrame,
+  fps,
+  isPlaying,
+  icons,
+  onStart,
+  onStepBackward,
+  onTogglePlay,
+  onStepForward,
+  onEnd,
+}: {
+  currentFrame: number;
+  maxFrame: number;
+  fps: number;
+  isPlaying: boolean;
+  icons: {
+    skipStart: React.ReactNode;
+    stepBackward: React.ReactNode;
+    playPause: React.ReactNode;
+    stepForward: React.ReactNode;
+    skipEnd: React.ReactNode;
+  };
+  onStart: () => void;
+  onStepBackward: () => void;
+  onTogglePlay: () => void;
+  onStepForward: () => void;
+  onEnd: () => void;
+}) {
+  const frameNumberWidth = `${Math.max(2, String(maxFrame).length)}ch`;
+  return (
+    <div
+      role="group"
+      aria-label="Timeline playback controls"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        minWidth: 0,
+      }}
+    >
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 3,
+          padding: 2,
+          border: `1px solid ${v('--elucim-editor-border-subtle')}`,
+          borderRadius: 999,
+          background: `color-mix(in srgb, ${v('--elucim-editor-input-bg')} 72%, transparent)`,
+        }}
+      >
+        <TimelineButton icon={icons.skipStart} title="Start" onClick={onStart} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
+        <TimelineButton icon={icons.stepBackward} title="Step back" onClick={onStepBackward} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
+        <TimelineButton icon={icons.playPause} title={isPlaying ? 'Pause' : 'Play'} onClick={onTogglePlay} active={isPlaying} size={PLAYBACK_PRIMARY_BUTTON_SIZE} variant="primary" />
+        <TimelineButton icon={icons.stepForward} title="Step forward" onClick={onStepForward} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
+        <TimelineButton icon={icons.skipEnd} title="End" onClick={onEnd} size={PLAYBACK_BUTTON_SIZE} variant="ghost" />
+      </div>
+      <div
+        aria-label={`Frame ${currentFrame} of ${maxFrame} at ${fps} frames per second`}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'baseline',
+          gap: 5,
+          color: v('--elucim-editor-text-secondary'),
+          fontVariantNumeric: 'tabular-nums',
+          fontSize: 10,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <span style={{ width: frameNumberWidth, color: v('--elucim-editor-fg'), fontWeight: 700, textAlign: 'right' }}>{currentFrame}</span>
+        <span>/</span>
+        <span style={{ width: frameNumberWidth }}>{maxFrame}</span>
+        <span style={{ color: v('--elucim-editor-text-muted') }}>{fps}fps</span>
+      </div>
+    </div>
+  );
+}
+
+function TimelineButton({ icon, title, onClick, active, size = 28, variant = 'default' }: {
+  icon: React.ReactNode;
+  title: string;
+  onClick: () => void;
+  active?: boolean;
+  size?: number;
+  variant?: 'default' | 'ghost' | 'primary';
+}) {
+  const primary = variant === 'primary';
+  const ghost = variant === 'ghost';
+  return (
+    <button
+      type="button"
+      aria-label={title}
+      title={title}
+      onClick={onClick}
+      style={{
+        width: size,
+        height: size,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        border: ghost ? 'none' : `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
+        borderRadius: 999,
+        background: active
+          ? `color-mix(in srgb, ${v('--elucim-editor-accent')} ${primary ? '28%' : '20%'}, transparent)`
+          : primary
+            ? v('--elucim-editor-input-bg')
+            : 'transparent',
+        color: active ? v('--elucim-editor-accent') : v('--elucim-editor-fg'),
+        cursor: 'pointer',
+        padding: 0,
+      }}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/packages/editor/src/timeline/constants.ts
+++ b/packages/editor/src/timeline/constants.ts
@@ -1,0 +1,37 @@
+export const TRACK_HEIGHT = 30;
+export const RULER_HEIGHT = 24;
+export const CLIP_HEADER_HEIGHT = 46;
+export const LABEL_WIDTH = 156;
+export const MOTION_RAIL_WIDTH = 34;
+export const MOTION_LIST_WIDTH = 140;
+export const MOTION_DETAILS_WIDTH = 300;
+export const PLAYBACK_BUTTON_SIZE = 24;
+export const PLAYBACK_PRIMARY_BUTTON_SIZE = 30;
+
+export const EASING_OPTIONS = [
+  'linear',
+  'easeInQuad',
+  'easeOutQuad',
+  'easeInOutQuad',
+  'easeInCubic',
+  'easeOutCubic',
+  'easeInOutCubic',
+  'easeInSine',
+  'easeOutSine',
+  'easeInOutSine',
+  'easeOutElastic',
+  'easeOutBounce',
+  'easeInBack',
+  'easeOutBack',
+];
+
+export const ANIMATABLE_PROPERTIES = ['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke'] as const;
+export const WRAPPER_TYPES = new Set(['fadeIn', 'fadeOut', 'draw', 'write', 'transform', 'morph', 'stagger', 'parallel']);
+
+export const ENTRY_NODE_ID = '__entry__';
+export const EXIT_NODE_ID = '__exit__';
+
+export const RESERVED_STATE_EVENT_NAMES = new Set(['complete', 'entry', 'exit', 'next']);
+export const EVENT_PRESETS = ['onClick', 'reset', 'onKey'] as const;
+export const ENTRY_EVENT_PRESETS = ['onStart', 'onClick', 'onKey'] as const;
+export const EVENT_PRESET_SET = new Set<string>([...EVENT_PRESETS, ...ENTRY_EVENT_PRESETS]);

--- a/packages/editor/src/timeline/keyframeValue.ts
+++ b/packages/editor/src/timeline/keyframeValue.ts
@@ -1,0 +1,4 @@
+export function parseKeyframeValue(value: string): unknown {
+  const numeric = Number(value);
+  return value.trim() !== '' && Number.isFinite(numeric) ? numeric : value;
+}

--- a/packages/editor/src/timeline/stateMachineHelpers.ts
+++ b/packages/editor/src/timeline/stateMachineHelpers.ts
@@ -1,0 +1,92 @@
+import type { ElucimStateMachine, ElucimTransition } from '@elucim/dsl';
+import { EVENT_PRESET_SET, RESERVED_STATE_EVENT_NAMES } from './constants';
+
+export function displayKeyName(key: string): string | undefined {
+  if (key === 'Tab') return undefined;
+  if (key === ' ') return 'Space';
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+export function getStateTriggerTransitions(machine: ElucimStateMachine, stateId: string): ElucimTransition[] {
+  return (machine.transitions ?? []).filter(transition => (transition.from === stateId || transition.from === 'any') && transition.trigger);
+}
+
+export function getEntryTriggerTransitions(machine: ElucimStateMachine): ElucimTransition[] {
+  return (machine.transitions ?? []).filter(transition => transition.from === 'entry' && transition.trigger);
+}
+
+export function getStateCompleteTransition(machine: ElucimStateMachine, stateId: string): ElucimTransition | undefined {
+  return (machine.transitions ?? []).find(transition => transition.from === stateId && transition.exitTime !== undefined);
+}
+
+export function getEntryTransition(machine: ElucimStateMachine): ElucimTransition | undefined {
+  return (machine.transitions ?? []).find(transition => transition.from === 'entry');
+}
+
+export function getEntryTargetStateId(machine: ElucimStateMachine): string | undefined {
+  const entryTarget = getEntryTransition(machine)?.to;
+  if (entryTarget && entryTarget !== 'entry' && entryTarget !== 'exit' && machine.states[entryTarget]) return entryTarget;
+  return machine.states[machine.entry] ? machine.entry : Object.keys(machine.states)[0];
+}
+
+export function resolveTransitionTarget(machine: ElucimStateMachine, transition: ElucimTransition): string | 'exit' | undefined {
+  if (transition.to === 'exit') return 'exit';
+  if (transition.to === 'entry') return getEntryTargetStateId(machine);
+  return machine.states[transition.to] ? transition.to : undefined;
+}
+
+export function getPreviewTransition(machine: ElucimStateMachine, stateId: string, eventName: string, key?: string): ElucimTransition | undefined {
+  if (eventName === 'complete' || eventName === 'next') return getStateCompleteTransition(machine, stateId);
+  return (machine.transitions ?? []).find(transition => {
+    if ((transition.from !== stateId && transition.from !== 'any') || transition.trigger !== eventName) return false;
+    return eventName !== 'onKey' || key === undefined || (transition.key ?? '').toLowerCase() === key.toLowerCase();
+  });
+}
+
+export function previewEventLabel(transition: ElucimTransition): string {
+  switch (transition.trigger) {
+    case 'onClick':
+      return 'Click';
+    case 'reset':
+      return 'Reset';
+    case 'onKey':
+      return transition.key ? `Press ${transition.key}` : 'Press key';
+    default:
+      return transition.trigger ?? transition.id;
+  }
+}
+
+export function createUniqueTransitionId(machine: ElucimStateMachine, preferred: string): string {
+  const existing = new Set((machine.transitions ?? []).map(transition => transition.id));
+  if (!existing.has(preferred)) return preferred;
+  let index = 2;
+  while (existing.has(`${preferred}-${index}`)) index += 1;
+  return `${preferred}-${index}`;
+}
+
+export function pruneUnusedTriggerInputs(
+  inputs: ElucimStateMachine['inputs'],
+  transitions: ElucimTransition[] | undefined,
+): ElucimStateMachine['inputs'] {
+  if (!inputs) return undefined;
+  const usedTriggers = new Set((transitions ?? []).map(transition => transition.trigger).filter((trigger): trigger is string => Boolean(trigger)));
+  const nextInputs = Object.fromEntries(Object.entries(inputs).filter(([inputId, input]) => input.type !== 'trigger' || usedTriggers.has(inputId)));
+  return Object.keys(nextInputs).length > 0 ? nextInputs : undefined;
+}
+
+export function isAvailableTransitionTrigger(machine: ElucimStateMachine, transition: ElucimTransition, trigger: string): boolean {
+  if (!trigger || RESERVED_STATE_EVENT_NAMES.has(trigger)) return false;
+  return !(machine.transitions ?? []).some(current => {
+    if (current.id === transition.id || current.from !== transition.from || current.exitTime !== undefined || current.trigger !== trigger) return false;
+    if (trigger === 'onKey') return (current.key ?? '').toLowerCase() === (transition.key ?? '').toLowerCase();
+    return true;
+  });
+}
+
+export function transitionTriggerLabel(transition: ElucimTransition): string {
+  if (transition.from === 'entry') return transition.trigger ?? 'onStart';
+  if (transition.trigger === 'onKey') return transition.key ? `Key: ${transition.key}` : 'Key';
+  if (transition.trigger && EVENT_PRESET_SET.has(transition.trigger)) return transition.trigger;
+  return transition.exitTime !== undefined ? 'Next' : `Event: ${transition.trigger ?? transition.id}`;
+}

--- a/packages/editor/src/timeline/styles.ts
+++ b/packages/editor/src/timeline/styles.ts
@@ -1,0 +1,86 @@
+import type React from 'react';
+import { v } from '../theme/tokens';
+
+export const chromeTabButtonStyle = (active: boolean, disabled = false): React.CSSProperties => ({
+  minHeight: 24,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 5,
+  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
+  borderRadius: 999,
+  background: active ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 14%, transparent)` : 'transparent',
+  color: disabled ? v('--elucim-editor-text-disabled') : active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  fontSize: 10,
+  fontWeight: 700,
+  padding: '3px 9px',
+});
+
+export const verticalMotionButtonStyle = (active: boolean, disabled = false): React.CSSProperties => ({
+  width: 24,
+  height: 24,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
+  borderRadius: 7,
+  background: active ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 16%, transparent)` : 'transparent',
+  color: disabled ? v('--elucim-editor-text-disabled') : active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  fontSize: 11,
+  fontWeight: 800,
+  padding: 0,
+});
+
+export const motionListActionButtonStyle = (active: boolean, visible = true): React.CSSProperties => ({
+  width: 22,
+  height: 22,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
+  borderRadius: 6,
+  background: active ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 14%, transparent)` : 'transparent',
+  color: active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
+  cursor: 'pointer',
+  opacity: visible ? 1 : 0,
+  pointerEvents: visible ? 'auto' : 'none',
+  padding: 0,
+});
+
+export const canvasOverlayButtonStyle = (active: boolean, disabled = false): React.CSSProperties => ({
+  width: 28,
+  height: 28,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px solid ${active ? v('--elucim-editor-accent') : v('--elucim-editor-border-subtle')}`,
+  borderRadius: 7,
+  background: active
+    ? `color-mix(in srgb, ${v('--elucim-editor-accent')} 18%, ${v('--elucim-editor-input-bg')})`
+    : `color-mix(in srgb, ${v('--elucim-editor-input-bg')} 88%, transparent)`,
+  color: disabled ? v('--elucim-editor-text-disabled') : active ? v('--elucim-editor-fg') : v('--elucim-editor-text-secondary'),
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  padding: 0,
+});
+
+export const inspectorInputStyle: React.CSSProperties = {
+  background: v('--elucim-editor-surface'),
+  color: v('--elucim-editor-fg'),
+  border: `1px solid ${v('--elucim-editor-border')}`,
+  borderRadius: 4,
+  padding: '4px 6px',
+  fontSize: 11,
+};
+
+export const motionInspectorPanelStyle: React.CSSProperties = {
+  borderLeft: `1px solid ${v('--elucim-editor-border')}`,
+  padding: 10,
+  display: 'grid',
+  gap: 8,
+  alignContent: 'start',
+  background: v('--elucim-editor-input-bg'),
+  minHeight: 0,
+  overflowY: 'auto',
+};

--- a/packages/editor/src/timeline/timelineRows.ts
+++ b/packages/editor/src/timeline/timelineRows.ts
@@ -1,0 +1,43 @@
+import type { ElementNode } from '@elucim/dsl';
+import { getElementId } from '../state/types';
+import { WRAPPER_TYPES } from './constants';
+import type { TrackRow } from './types';
+
+export function getChildren(element: ElementNode): ElementNode[] {
+  return 'children' in element && Array.isArray((element as { children?: unknown }).children)
+    ? (element as { children: ElementNode[] }).children
+    : [];
+}
+
+export function getRows(elements: ElementNode[], expandedIds: Set<string>, parentPath = 'root', depth = 0): TrackRow[] {
+  return elements.flatMap((element, index) => {
+    const id = getElementId(element, index, parentPath);
+    const children = getChildren(element);
+    const label = ('id' in element && element.id) ? element.id : `${element.type}[${index}]`;
+    const row: TrackRow = {
+      element,
+      id,
+      label,
+      rootIndex: depth === 0 ? index : -1,
+      depth,
+      hasChildren: children.length > 0,
+      isTopLevel: depth === 0,
+    };
+    return expandedIds.has(id)
+      ? [row, ...getRows(children, expandedIds, id, depth + 1)]
+      : [row];
+  });
+}
+
+export function getAnimationValues(element: ElementNode): { fadeIn: number; fadeOut: number; draw: number } {
+  const el = element as ElementNode & { duration?: number; fadeIn?: number; fadeOut?: number; draw?: number };
+  if (el.type === 'fadeIn') return { fadeIn: el.duration ?? 0, fadeOut: 0, draw: 0 };
+  if (el.type === 'fadeOut') return { fadeIn: 0, fadeOut: el.duration ?? 0, draw: 0 };
+  if (el.type === 'draw' || el.type === 'write') return { fadeIn: 0, fadeOut: 0, draw: el.duration ?? 0 };
+  if (WRAPPER_TYPES.has(el.type)) return { fadeIn: 0, fadeOut: 0, draw: el.duration ?? 0 };
+  return { fadeIn: el.fadeIn ?? 0, fadeOut: el.fadeOut ?? 0, draw: el.draw ?? 0 };
+}
+
+export function getAnimationUpdateProp(element: ElementNode, prop: 'fadeIn' | 'fadeOut' | 'draw'): 'fadeIn' | 'fadeOut' | 'draw' | 'duration' {
+  return WRAPPER_TYPES.has(element.type) ? 'duration' : prop;
+}

--- a/packages/editor/src/timeline/types.ts
+++ b/packages/editor/src/timeline/types.ts
@@ -1,0 +1,66 @@
+import type { ElementNode, ElucimStateMachine, ElucimTimeline, ElucimTransition } from '@elucim/dsl';
+
+export type GraphLayoutDirection = 'horizontal' | 'vertical';
+
+export interface StateMachinePreviewState {
+  machineId: string;
+  stateId: string;
+  timelineId?: string;
+  event?: string;
+  previousStateId?: string;
+  activeTransitionId?: string;
+  logicalStatePath?: string[];
+  exited?: boolean;
+  finished?: boolean;
+}
+
+export interface StateMachineGraphNodeData extends Record<string, unknown> {
+  kind: 'entry' | 'state' | 'exit';
+  stateId: string;
+  timeline?: string;
+  selected: boolean;
+  direction: GraphLayoutDirection;
+  canDelete?: boolean;
+  onDelete?: () => void;
+}
+
+export interface StateMachineGraphEdgeData extends Record<string, unknown> {
+  label: string;
+  detail?: string;
+  stateId?: string;
+  selected: boolean;
+  backEdge: boolean;
+  direction: GraphLayoutDirection;
+  onSelect?: () => void;
+}
+
+export interface SelectedTimelineItem {
+  type: 'animation';
+  timelineId: string;
+  trackIndex?: number;
+  keyframeIndex?: number;
+}
+
+export interface SelectedStateMachineItem {
+  type: 'stateMachine';
+  machineId: string;
+  stateId?: string;
+  transitionEvent?: string;
+}
+
+export type SelectedMotionItem = SelectedTimelineItem | SelectedStateMachineItem;
+
+export interface TrackRow {
+  element: ElementNode;
+  id: string;
+  label: string;
+  rootIndex: number;
+  depth: number;
+  hasChildren: boolean;
+  isTopLevel: boolean;
+}
+
+export type TimelineTrack = ElucimTimeline['tracks'][number];
+export type TimelineKeyframe = TimelineTrack['keyframes'][number];
+export type StateMachineState = ElucimStateMachine['states'][string];
+export type StateMachineTransitionPatch = Partial<ElucimTransition>;


### PR DESCRIPTION
## Summary
- extracts Timeline presentation and helper seams into focused timeline modules
- moves animation inspector, playback controls, animation bars, timeline row helpers, state-machine helpers, constants, styles, and shared types out of Timeline.tsx
- adds focused unit tests for extracted helper/control seams
- updates Playwright editor tests to target the current Objects/Create/Polish dock and motion-tab UI

Fixes #46

## Validation
- pnpm build
- pnpm --filter @elucim/editor test
- pnpm --filter @elucim/editor lint
- pnpm lint
- pnpm test
- pnpm test:e2e