### PR TITLE
Cover editor chrome and Polish workflows in e2e

### DIFF
--- a/packages/e2e/tests/editor-shell.spec.ts
+++ b/packages/e2e/tests/editor-shell.spec.ts
@@ -50,4 +50,57 @@ test.describe('editor shell', () => {
     await expect(page.getByText(/Polish is for scene metadata/)).toBeVisible();
     await expect(page.getByLabel('Document intent')).toBeVisible();
   });
+
+  test('toggles top bar panels without duplicate canvas panel controls', async ({ page }) => {
+    await openEditor(page);
+
+    await expect(page.getByRole('button', { name: 'Hide left panel' })).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Hide timeline' })).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Show Inspector' })).toHaveCount(1);
+    await expect(page.locator('.elucim-editor-canvas').getByRole('button', { name: /panel|timeline|inspector/i })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Hide left panel' }).click();
+    await expect(page.getByRole('tablist', { name: 'Left editor panel' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Show left panel' })).toHaveCount(1);
+    await expect(page.locator('.elucim-editor-canvas').getByRole('button', { name: /panel|timeline|inspector/i })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Hide Timeline' }).click();
+    await expect(page.getByRole('tab', { name: 'Animations motion tab' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Show timeline' })).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'Show Inspector' }).click();
+    await expect(page.locator('.elucim-editor-inspector')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Hide Inspector' })).toHaveCount(1);
+    await page.getByRole('button', { name: 'Hide Inspector' }).click();
+    await expect(page.locator('.elucim-editor-inspector')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Show Inspector' })).toHaveCount(1);
+  });
+
+  test('reaches left panel tabs and applies Polish nudge feedback', async ({ page }) => {
+    await openEditor(page);
+
+    await page.getByRole('tab', { name: 'Objects' }).click();
+    await expect(page.getByRole('tab', { name: 'Objects' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('treeitem').first()).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Create' }).click();
+    await expect(page.getByRole('tab', { name: 'Create' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByTitle('Rectangle')).toBeVisible();
+
+    await page.getByRole('tab', { name: 'Polish' }).click();
+    await expect(page.getByRole('tab', { name: 'Polish' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByText('Polish suggestions')).toBeVisible();
+    await expect(page.getByText('What will change').first()).toBeVisible();
+    await expect(page.getByText('Impact:').first()).toBeVisible();
+    await expect(page.getByText('Review level:').first()).toBeVisible();
+
+    await page.getByRole('button', { name: 'Apply nudge Mark document as refined' }).click();
+
+    await expect(page.getByText('Applied Mark document as refined')).toBeVisible();
+    await expect(page.getByText('Result is visible in Scene metadata.')).toBeVisible();
+    await expect(page.getByText(/Safe · 1 change/)).toBeVisible();
+    await expect(page.getByText('Matched preview: Updated document metadata.')).toBeVisible();
+    await expect(page.getByLabel('Polish level')).toHaveValue('refined');
+    await expect(page.getByRole('button', { name: 'Apply nudge Mark document as refined' })).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #45.\n\n## Summary\n- Adds browser coverage for top-bar panel toggles and verifies duplicate canvas panel controls stay absent\n- Covers Objects, Create, and Polish left-panel tab reachability\n- Covers applying a Polish nudge with explicit feedback and visible metadata update\n\n## Validation\n- pnpm --filter @elucim/e2e test -- tests/editor-shell.spec.ts --reporter=line\n- pnpm --filter @elucim/e2e lint\n- pnpm test:e2e