### PR TITLE
test: configure React act environment

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: [],
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/packages/core/vitest.setup.ts
+++ b/packages/core/vitest.setup.ts
@@ -1,0 +1,1 @@
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/dsl/vitest.config.ts
+++ b/packages/dsl/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+}));

--- a/packages/dsl/vitest.setup.ts
+++ b/packages/dsl/vitest.setup.ts
@@ -1,0 +1,1 @@
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+}));

--- a/packages/editor/vitest.setup.ts
+++ b/packages/editor/vitest.setup.ts
@@ -1,0 +1,1 @@
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;


### PR DESCRIPTION
## Summary\n- Sets the React act test environment flag in core, DSL, and editor Vitest setup\n- Adds Vitest configs for DSL/editor that merge existing Vite config and load setup files\n- Keeps npm always-auth warnings out of repo changes because no repo .npmrc/config contains that setting\n\n## Validation\n- pnpm --filter @elucim/core test\n- pnpm --filter @elucim/dsl test\n- pnpm --filter @elucim/editor test\n- pnpm lint