### PR TITLE
test: replace deprecated React act imports

### DIFF
--- a/packages/core/src/__tests__/bezierCurve.test.tsx
+++ b/packages/core/src/__tests__/bezierCurve.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { act } from 'react';
 import ReactDOM from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
 import { describe, it, expect } from 'vitest';
 import { BezierCurve, type BezierCurveProps } from '../primitives/BezierCurve';
 import { ElucimContext } from '../context';

--- a/packages/core/src/__tests__/imageResolverAsync.test.tsx
+++ b/packages/core/src/__tests__/imageResolverAsync.test.tsx
@@ -1,10 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import React from 'react';
+import React, { act } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import ReactDOM from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
 import { ImageResolverProvider, type ImageResolverFn } from '../providers/ImageResolverProvider';
 import { Image } from '../primitives/Image';
 import { ElucimContext } from '../context';

--- a/packages/core/src/__tests__/player.test.tsx
+++ b/packages/core/src/__tests__/player.test.tsx
@@ -1,10 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import React from 'react';
+import React, { act } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ReactDOM from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
 import { Player, type PlayerRef } from '../components/Player';
 
 // Default matchMedia mock — no reduced motion


### PR DESCRIPTION
## Summary\n- Replaces deprecated react-dom/test-utils act imports with react act in core tests\n- Removes the ReactDOMTestUtils.act deprecation warning from the core test run\n\n## Validation\n- pnpm --filter @elucim/core test\n- pnpm --filter @elucim/core lint