### PR TITLE
ci: mirror packages to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  packages: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -45,6 +46,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -78,3 +80,34 @@ jobs:
       - name: Publish @elucim/cli
         if: ${{ needs.release-please.outputs.cli_release == 'true' || (github.event_name == 'workflow_dispatch' && inputs.package == 'cli') }}
         run: pnpm --filter @elucim/cli publish --access public --no-git-checks --provenance
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://npm.pkg.github.com
+          scope: '@sethjuarez'
+
+      - name: Publish @sethjuarez/elucim-core to GitHub Packages
+        if: ${{ needs.release-please.outputs.core_release == 'true' }}
+        run: node scripts/publish-github-package.mjs @elucim/core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish @sethjuarez/elucim-dsl to GitHub Packages
+        if: ${{ needs.release-please.outputs.dsl_release == 'true' }}
+        run: node scripts/publish-github-package.mjs @elucim/dsl
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish @sethjuarez/elucim-editor to GitHub Packages
+        if: ${{ needs.release-please.outputs.editor_release == 'true' }}
+        run: node scripts/publish-github-package.mjs @elucim/editor
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish @sethjuarez/elucim-cli to GitHub Packages
+        if: ${{ needs.release-please.outputs.cli_release == 'true' || (github.event_name == 'workflow_dispatch' && inputs.package == 'cli') }}
+        run: node scripts/publish-github-package.mjs @elucim/cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/publish-github-package.mjs
+++ b/scripts/publish-github-package.mjs
@@ -1,0 +1,159 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const githubRegistry = 'https://npm.pkg.github.com';
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const packageAliases = {
+  '@elucim/core': '@sethjuarez/elucim-core',
+  '@elucim/dsl': '@sethjuarez/elucim-dsl',
+  '@elucim/editor': '@sethjuarez/elucim-editor',
+  '@elucim/cli': '@sethjuarez/elucim-cli',
+};
+
+const [, , sourcePackageName, ...flags] = process.argv;
+const dryRun = flags.includes('--dry-run');
+
+if (!sourcePackageName || !packageAliases[sourcePackageName]) {
+  throw new Error(`Usage: node scripts/publish-github-package.mjs ${Object.keys(packageAliases).join('|')}`);
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packageDirectory = packageDirectoryFor(sourcePackageName);
+const packageJsonPath = resolve(repoRoot, packageDirectory, 'package.json');
+const sourcePackageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+const targetPackageName = packageAliases[sourcePackageName];
+const version = sourcePackageJson.version;
+
+if (!dryRun && isAlreadyPublished(targetPackageName, version)) {
+  console.log(`${targetPackageName}@${version} already exists in GitHub Packages; skipping.`);
+  process.exit(0);
+}
+
+const tempRoot = await mkdtemp(join(tmpdir(), 'elucim-github-package-'));
+
+try {
+  const packDestination = join(tempRoot, 'packed');
+  await mkdir(packDestination, { recursive: true });
+  run(pnpm, ['--filter', sourcePackageName, 'pack', '--pack-destination', packDestination], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+
+  const tarball = join(packDestination, packageTarballName(sourcePackageJson));
+  if (!existsSync(tarball)) {
+    throw new Error(`Expected packed artifact ${tarball} for ${sourcePackageName}`);
+  }
+
+  const extractDestination = join(tempRoot, 'extract');
+  await mkdir(extractDestination, { recursive: true });
+  run('tar', ['-xzf', tarball, '-C', extractDestination], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+
+  const stagedPackageRoot = join(extractDestination, 'package');
+  const stagedPackageJsonPath = join(stagedPackageRoot, 'package.json');
+  const stagedPackageJson = JSON.parse(await readFile(stagedPackageJsonPath, 'utf8'));
+  stagedPackageJson.name = targetPackageName;
+  stagedPackageJson.publishConfig = {
+    registry: githubRegistry,
+  };
+  rewriteOwnedDependencies(stagedPackageJson, version);
+  await writeFile(stagedPackageJsonPath, `${JSON.stringify(stagedPackageJson, null, 2)}\n`);
+
+  if (dryRun) {
+    run(npm, ['pack', '--dry-run'], {
+      cwd: stagedPackageRoot,
+      stdio: 'inherit',
+    });
+    console.log(`Dry run prepared ${targetPackageName}@${version} for GitHub Packages.`);
+    process.exit(0);
+  }
+
+  run(npm, ['publish', '--registry', githubRegistry, '--ignore-scripts'], {
+    cwd: stagedPackageRoot,
+    stdio: 'inherit',
+  });
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+function packageDirectoryFor(packageName) {
+  const unscopedName = packageName.replace('@elucim/', '');
+  return `packages/${unscopedName}`;
+}
+
+function packageTarballName(packageJson) {
+  const packageFileName = packageJson.name.replace(/^@/, '').replaceAll('/', '-');
+  return `${packageFileName}-${packageJson.version}.tgz`;
+}
+
+function isAlreadyPublished(packageName, version) {
+  try {
+    const output = run(npm, ['view', `${packageName}@${version}`, 'version', '--registry', githubRegistry], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return output.trim() === version;
+  } catch (error) {
+    const errorOutput = `${error.stderr?.toString() ?? ''}\n${error.stdout?.toString() ?? ''}`;
+    if (errorOutput.includes('E404') || errorOutput.includes('404 Not Found')) {
+      return false;
+    }
+
+    throw new Error(`Unable to check ${packageName}@${version} in GitHub Packages:\n${errorOutput}`);
+  }
+}
+
+function rewriteOwnedDependencies(packageJson, version) {
+  for (const dependencyField of ['dependencies', 'optionalDependencies']) {
+    const dependencies = packageJson[dependencyField];
+    if (!dependencies) continue;
+
+    for (const [sourceName, targetName] of Object.entries(packageAliases)) {
+      if (dependencies[sourceName]) {
+        dependencies[sourceName] = toAliasDependency(targetName, dependencies[sourceName]);
+      }
+    }
+  }
+}
+
+function toAliasDependency(targetName, sourceSpec) {
+  const aliasPrefix = 'npm:';
+  if (sourceSpec.startsWith(aliasPrefix)) {
+    const aliasSpec = sourceSpec.slice(aliasPrefix.length);
+    const versionStart = aliasSpec.startsWith('@') ? aliasSpec.indexOf('@', 1) : aliasSpec.indexOf('@');
+    if (versionStart === -1) {
+      throw new Error(`Unable to preserve aliased dependency version from ${sourceSpec}`);
+    }
+    return `${aliasPrefix}${targetName}@${aliasSpec.slice(versionStart + 1)}`;
+  }
+
+  return `${aliasPrefix}${targetName}@${sourceSpec}`;
+}
+
+function run(command, args, options) {
+  if (process.platform === 'win32') {
+    return execFileSync(process.env.ComSpec ?? 'cmd.exe', ['/d', '/s', '/c', [command, ...args].map(quoteWindowsArg).join(' ')], {
+      ...options,
+      windowsHide: true,
+    });
+  }
+
+  return execFileSync(command, args, {
+    ...options,
+    windowsHide: true,
+  });
+}
+
+function quoteWindowsArg(value) {
+  if (!/[\s"]/u.test(value)) return value;
+  return `"${value.replaceAll('"', '\\"')}"`;
+}


### PR DESCRIPTION
## Summary
- mirror Elucim release packages to GitHub Packages under @sethjuarez/* aliases
- preserve existing npmjs.org release publish flow unchanged
- stage temporary mirror package metadata so source package names/imports remain @elucim/*

## Validation
- pnpm test:package-smoke
- mirror dry-runs for core, dsl, editor, cli
- published GitHub Packages alias install/import smoke