### PR TITLE
feat: add timeline-native scene camera

### DIFF
--- a/packages/dsl/README.md
+++ b/packages/dsl/README.md
@@ -136,6 +136,38 @@ function App() {
 }
 ```
 
+### Timeline camera
+
+Camera animation belongs to a timeline, rather than to a synthetic root group. A camera keyframe describes the scene rectangle to view at a frame. The renderer maps that rectangle through a clipped SVG viewport, so the same document behaves consistently in browser previews, SVG rendering, and PNG export.
+
+```ts
+const doc: ElucimDocument = {
+  // scene and elements omitted
+  version: '2.0',
+  scene: { type: 'player', width: 1280, height: 720, children: ['detail'] },
+  elements: { /* ... */ },
+  timelines: {
+    focusDetail: {
+      id: 'focusDetail',
+      duration: 45,
+      tracks: [],
+      camera: {
+        coordinateSpace: 'scene',
+        fit: 'cover',
+        keyframes: [
+          { frame: 0, viewport: { x: 0, y: 0, width: 1280, height: 720 } },
+          { frame: 45, viewport: { x: 720, y: 180, width: 360, height: 240 }, easing: 'easeInOutCubic' },
+        ],
+      },
+    },
+  },
+};
+```
+
+- `coordinateSpace: 'scene'` (default) uses scene pixels. Use `'normalized'` for rectangles in the unit scene `[0, 1] × [0, 1]`.
+- `fit: 'cover'` (default) fills the scene surface without distortion; `'contain'` keeps the entire focus rectangle visible and may letterbox.
+- Author cameras as `timeline.camera` keyframes. State machines select the active timeline camera through their normal state path. Static scene and render-tree camera fields are rejected.
+
 ## API
 
 ### `<DslRenderer dsl={doc} />`
@@ -190,8 +222,10 @@ Renders a document to an SVG string without a browser DOM — useful for server-
 
 ```ts
 import { renderToSvgString } from '@elucim/dsl';
-const svg = renderToSvgString(myDoc, 0);
+const svg = renderToSvgString(myDoc, 0, { timelineId: 'focusDetail' });
 ```
+
+Pass `timelineId` to evaluate that normalized timeline, including its camera, at the requested frame. `renderToPng(doc, frame, { timelineId })` accepts the same option for browser-side PNG export.
 
 ### Agent authoring helpers
 

--- a/packages/dsl/src/__tests__/documentCompatibility.test.ts
+++ b/packages/dsl/src/__tests__/documentCompatibility.test.ts
@@ -186,6 +186,42 @@ describe('Elucim Document compatibility foundation', () => {
     expect(validate(renderable).valid).toBe(true);
   });
 
+  it('rejects static render-tree cameras during canonical migration', () => {
+    const renderable: RenderableDocument = {
+      version: 'render-tree',
+      root: {
+        type: 'scene',
+        width: 800,
+        height: 600,
+        durationInFrames: 1,
+        camera: { viewport: { x: 100, y: 75, width: 400, height: 300 }, fit: 'cover' },
+        children: [],
+      },
+    };
+
+    expect(() => createDocumentFromRenderable(renderable)).toThrow(
+      'Render-tree camera is not supported. Use timeline.camera keyframes in an Elucim Document.',
+    );
+  });
+
+  it('rejects static scene cameras in canonical documents', () => {
+    const result = validateDocument({
+      version: '2.0',
+      scene: {
+        type: 'scene',
+        children: [],
+        camera: { viewport: { x: 0, y: 0, width: 800, height: 600 } },
+      },
+      elements: {},
+    });
+
+    expect(result.errors).toContainEqual({
+      path: 'scene.camera',
+      message: 'Scene camera is not part of Elucim Documents. Use timeline.camera keyframes.',
+      severity: 'error',
+    });
+  });
+
   it('rejects old rootless visual documents instead of migrating them', () => {
     expect(() => normalizeDocument({
       version: 1,

--- a/packages/dsl/src/__tests__/documentStateMachine.test.ts
+++ b/packages/dsl/src/__tests__/documentStateMachine.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   advanceStateMachineRunFrame,
+  applyTimelineFrames,
+  evaluateTimelineCameraFrames,
   dispatchStateMachineRunEvent,
   getInitialStateSnapshot,
   getStateMachineRunVisualFrames,
@@ -193,6 +195,35 @@ describe('document state machines', () => {
       currentFrame: 0,
       finished: true,
     })).toEqual(frames);
+  });
+
+  it('does not let an unrelated timeline override the active state camera', () => {
+    const cameraDoc: ElucimDocument = {
+      ...doc,
+      timelines: {
+        ...doc.timelines,
+        idle: {
+          ...doc.timelines!.idle,
+          camera: {
+            keyframes: [{ frame: 0, viewport: { x: 0, y: 0, width: 800, height: 600 } }],
+          },
+        },
+        outro: {
+          ...doc.timelines!.outro,
+          camera: {
+            keyframes: [{ frame: 0, viewport: { x: 400, y: 300, width: 200, height: 150 } }],
+          },
+        },
+      },
+    };
+    const frames = getStateMachineVisualFrames(cameraDoc, 'presentation', {
+      statePath: ['idle'],
+      currentStateId: 'idle',
+      currentFrame: 0,
+    });
+
+    expect(frames).toContainEqual({ timelineId: 'outro', frame: 0, applyCamera: false });
+    expect(evaluateTimelineCameraFrames(cameraDoc, frames)?.viewport).toEqual({ x: 0, y: 0, width: 800, height: 600 });
   });
 
   it('validates transition targets', () => {

--- a/packages/dsl/src/__tests__/documentTimeline.test.ts
+++ b/packages/dsl/src/__tests__/documentTimeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyCommand, applyTimelineFrame, applyTimelineFrames, createRenderableDocument, evaluateTimeline, validateDocument, type ElucimDocument } from '../index';
+import { applyCommand, applyTimelineFrame, applyTimelineFrames, createRenderableDocument, evaluateCameraTrack, evaluateTimeline, evaluateTimelineCameraFrames, validateDocument, type ElucimDocument } from '../index';
 
 const doc: ElucimDocument = {
   version: '2.0',
@@ -121,6 +121,129 @@ describe('document timelines and keyframes', () => {
     expect(title.scale).toBe(1);
     expect(title.translate).toEqual([0, 12]);
     expect(title.rotation).toBe(45);
+  });
+
+  it('interpolates a semantic camera viewport and applies it to the scene', () => {
+    const camera = {
+      coordinateSpace: 'normalized' as const,
+      fit: 'cover' as const,
+      keyframes: [
+        { frame: 0, viewport: { x: 0, y: 0, width: 1, height: 1 } },
+        { frame: 30, viewport: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 }, easing: 'linear' as const },
+      ],
+    };
+    const cameraDoc = {
+      ...doc,
+      timelines: {
+        camera: { id: 'camera', duration: 30, tracks: [], camera },
+      },
+    };
+    const next = applyTimelineFrame(cameraDoc, 'camera', 15);
+
+    expect(evaluateCameraTrack(camera, 15)).toEqual({
+      coordinateSpace: 'normalized',
+      fit: 'cover',
+      viewport: { x: 0.125, y: 0.125, width: 0.75, height: 0.75 },
+    });
+
+    expect(evaluateTimelineCameraFrames(cameraDoc, [{ timelineId: 'camera', frame: 15 }])?.viewport)
+      .toEqual({ x: 0.125, y: 0.125, width: 0.75, height: 0.75 });
+    expect(next).toEqual(cameraDoc);
+  });
+
+  it('uses the complete public easing set for camera interpolation', () => {
+    const camera = {
+      keyframes: [
+        { frame: 0, viewport: { x: 0, y: 0, width: 100, height: 100 } },
+        { frame: 10, viewport: { x: 100, y: 100, width: 50, height: 50 }, easing: 'easeInQuart' as const },
+      ],
+    };
+
+    expect(evaluateCameraTrack(camera, 5).viewport).toEqual({ x: 6.25, y: 6.25, width: 96.875, height: 96.875 });
+  });
+
+  it('keeps camera dimensions positive when an easing overshoots', () => {
+    const camera = {
+      keyframes: [
+        { frame: 0, viewport: { x: 0, y: 0, width: 100, height: 100 } },
+        { frame: 10, viewport: { x: 0, y: 0, width: 1, height: 1 }, easing: 'easeOutBack' as const },
+      ],
+    };
+
+    const viewport = evaluateCameraTrack(camera, 5).viewport;
+
+    expect(viewport.width).toBeGreaterThan(0);
+    expect(viewport.height).toBeGreaterThan(0);
+  });
+
+  it('rejects malformed camera keyframes with structured paths', () => {
+    const result = validateDocument({
+      ...doc,
+      timelines: {
+        camera: {
+          id: 'camera',
+          duration: 30,
+          tracks: [],
+          camera: {
+            coordinateSpace: 'normalized',
+            keyframes: [{ frame: 0, viewport: { x: 0, y: 0, width: 1.2, height: 1 } }],
+          },
+        },
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(error => error.path)).toContain('timelines.camera.camera.keyframes[0].viewport');
+  });
+
+  it('rejects invalid camera easing with a structured path', () => {
+    const result = validateDocument({
+      ...doc,
+      timelines: {
+        camera: {
+          id: 'camera',
+          duration: 30,
+          tracks: [],
+          camera: {
+            keyframes: [{
+              frame: 0,
+              viewport: { x: 0, y: 0, width: 100, height: 100 },
+              easing: 'not-an-easing',
+            }],
+          },
+        },
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(error => error.path)).toContain('timelines.camera.camera.keyframes[0].easing');
+  });
+
+  it('rejects non-finite camera spring easing settings', () => {
+    const result = validateDocument({
+      ...doc,
+      timelines: {
+        camera: {
+          id: 'camera',
+          duration: 30,
+          tracks: [],
+          camera: {
+            keyframes: [{
+              frame: 0,
+              viewport: { x: 0, y: 0, width: 100, height: 100 },
+              easing: { type: 'spring', stiffness: 'bad', damping: -1, mass: 0 },
+            }],
+          },
+        },
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(error => error.path)).toEqual(expect.arrayContaining([
+      'timelines.camera.camera.keyframes[0].easing.stiffness',
+      'timelines.camera.camera.keyframes[0].easing.damping',
+      'timelines.camera.camera.keyframes[0].easing.mass',
+    ]));
   });
 
   it('lets commands upsert and preview timeline clips', () => {

--- a/packages/dsl/src/__tests__/renderToSvgString.test.ts
+++ b/packages/dsl/src/__tests__/renderToSvgString.test.ts
@@ -68,4 +68,113 @@ describe('renderToSvgString', () => {
     expect(svg).toContain('<svg');
     expect(svg).toContain('<circle');
   });
+
+  it('maps a timeline camera through a clipped nested SVG viewport', () => {
+    const normalized: ElucimDocument = {
+      version: '2.0',
+      scene: {
+        type: 'scene',
+        width: 400,
+        height: 300,
+        children: ['circle'],
+      },
+      elements: {
+        circle: {
+          id: 'circle',
+          type: 'circle',
+          props: { type: 'circle', cx: 200, cy: 150, r: 50, fill: '#ff0000' },
+        },
+      },
+      timelines: {
+        focus: {
+          id: 'focus',
+          duration: 1,
+          tracks: [],
+          camera: {
+            coordinateSpace: 'scene',
+            fit: 'cover',
+            keyframes: [{ frame: 0, viewport: { x: 100, y: 75, width: 200, height: 150 } }],
+          },
+        },
+      },
+    };
+
+    const svg = renderToSvgString(normalized, 0, { timelineId: 'focus' });
+
+    expect(svg).toContain('data-elucim-camera-viewport');
+    expect(svg).toContain('viewBox="100 75 200 150"');
+    expect(svg).toContain('overflow="hidden"');
+  });
+
+  it('evaluates a selected timeline camera for static SVG export', () => {
+    const normalized: ElucimDocument = {
+      version: '2.0',
+      scene: { type: 'scene', width: 400, height: 300, children: ['circle'] },
+      elements: {
+        circle: {
+          id: 'circle',
+          type: 'circle',
+          props: { type: 'circle', cx: 200, cy: 150, r: 50, fill: '#ff0000' },
+        },
+      },
+      timelines: {
+        focus: {
+          id: 'focus',
+          duration: 20,
+          tracks: [],
+          camera: {
+            keyframes: [
+              { frame: 0, viewport: { x: 0, y: 0, width: 400, height: 300 } },
+              { frame: 20, viewport: { x: 100, y: 75, width: 200, height: 150 } },
+            ],
+          },
+        },
+      },
+    };
+
+    const svg = renderToSvgString(normalized, 10, { timelineId: 'focus' });
+
+    expect(svg).toContain('viewBox="50 37.5 300 225"');
+  });
+
+  it('keeps an explicitly selected timeline camera over the default state camera', () => {
+    const normalized: ElucimDocument = {
+      version: '2.0',
+      scene: { type: 'scene', width: 400, height: 300, children: ['circle'] },
+      elements: {
+        circle: {
+          id: 'circle',
+          type: 'circle',
+          props: { type: 'circle', cx: 200, cy: 150, r: 50, fill: '#ff0000' },
+        },
+      },
+      timelines: {
+        idle: {
+          id: 'idle',
+          duration: 1,
+          tracks: [],
+          camera: { keyframes: [{ frame: 0, viewport: { x: 0, y: 0, width: 400, height: 300 } }] },
+        },
+        focus: {
+          id: 'focus',
+          duration: 1,
+          tracks: [],
+          camera: { keyframes: [{ frame: 0, viewport: { x: 100, y: 75, width: 200, height: 150 } }] },
+        },
+      },
+      stateMachines: {
+        presentation: {
+          id: 'presentation',
+          entry: 'idle',
+          states: { idle: { timeline: 'idle' } },
+          transitions: [{ id: 'entry-idle', from: 'entry', to: 'idle', trigger: 'onStart' }],
+        },
+      },
+      defaultStateMachine: 'presentation',
+    };
+
+    const svg = renderToSvgString(normalized, 0, { timelineId: 'focus' });
+
+    expect(svg).toContain('viewBox="100 75 200 150"');
+  });
 });

--- a/packages/dsl/src/document.ts
+++ b/packages/dsl/src/document.ts
@@ -1,6 +1,12 @@
 export type {
   ElucimDocument as ElucimDocument,
   ElucimScene as ElucimScene,
+  ElucimCamera as ElucimCamera,
+  ElucimTimelineCamera as ElucimTimelineCamera,
+  ElucimCameraKeyframe as ElucimCameraKeyframe,
+  ElucimCameraViewport as ElucimCameraViewport,
+  ElucimCameraCoordinateSpace as ElucimCameraCoordinateSpace,
+  ElucimCameraFit as ElucimCameraFit,
   ElucimElement as ElucimElement,
   ElucimMetadata as ElucimMetadata,
   ElucimIntent as ElucimIntent,
@@ -69,6 +75,8 @@ export {
 export {
   applyTimelineFrame,
   applyTimelineFrames,
+  evaluateTimelineCameraFrames,
+  evaluateCameraTrack,
   evaluateTimeline,
 } from './documentModel/timeline';
 export {

--- a/packages/dsl/src/documentModel/compatibility.ts
+++ b/packages/dsl/src/documentModel/compatibility.ts
@@ -47,6 +47,9 @@ export function createDocumentFromRenderable(doc: RenderableDocument): ElucimDoc
   }
 
   const root = doc.root as SceneNode | PlayerNode;
+  if ('camera' in root) {
+    throw new Error('Render-tree camera is not supported. Use timeline.camera keyframes in an Elucim Document.');
+  }
   const state: MigrationState = { elements: {}, usedIds: new Set() };
   const children = root.children.map((child, index) => migrateElement(child, `root.${child.type}[${index}]`, undefined, state));
   const scene: ElucimScene = {
@@ -75,6 +78,7 @@ export function createDocumentFromRenderable(doc: RenderableDocument): ElucimDoc
   };
 }
 
+/** Projects a canonical document for rendering. */
 export function createRenderableDocument(doc: ElucimDocument): RenderableDocument {
   const children = doc.scene.children.map(id => restoreElement(doc, id));
   return {
@@ -97,7 +101,7 @@ export function createRenderableDocument(doc: ElucimDocument): RenderableDocumen
   };
 }
 
-function applyDefaultStateMachineInitialFrame(doc: ElucimDocument): ElucimDocument {
+export function applyDefaultStateMachineInitialFrame(doc: ElucimDocument): ElucimDocument {
   if (!doc.defaultStateMachine || !doc.stateMachines?.[doc.defaultStateMachine]) return doc;
   const snapshot = getInitialStateSnapshot(doc, doc.defaultStateMachine);
   const frames = getStateMachineVisualFrames(doc, doc.defaultStateMachine, {

--- a/packages/dsl/src/documentModel/stateMachine.ts
+++ b/packages/dsl/src/documentModel/stateMachine.ts
@@ -24,6 +24,8 @@ export interface ElucimStateEvent {
 export interface ElucimStateMachineVisualFrame {
   timelineId: string;
   frame: number;
+  /** Whether this frame may override a legacy scene-camera fallback. */
+  applyCamera?: boolean;
 }
 
 export interface ElucimStateMachineRun {
@@ -171,10 +173,28 @@ export function getStateMachineVisualFrames(
 ): ElucimStateMachineVisualFrame[] {
   const machine = getMachine(doc, machineId);
   if (options.exited || options.finished) {
-    return Object.entries(doc.timelines ?? {}).map(([timelineId, timeline]) => ({ timelineId, frame: timeline.duration }));
+    const frames: ElucimStateMachineVisualFrame[] = Object.entries(doc.timelines ?? {}).map(([timelineId, timeline]) => ({
+      timelineId,
+      frame: timeline.duration,
+      ...(timeline.camera ? { applyCamera: false } : {}),
+    }));
+    const activeTimelineId = !options.exited ? machine.states[options.currentStateId]?.timeline : undefined;
+    const activeTimeline = activeTimelineId ? doc.timelines?.[activeTimelineId] : undefined;
+    if (activeTimelineId && activeTimeline) {
+      frames.push({
+        timelineId: activeTimelineId,
+        frame: activeTimeline.duration,
+        ...(activeTimeline.camera ? { applyCamera: true } : {}),
+      });
+    }
+    return frames;
   }
   const path = options.statePath?.length ? options.statePath : [options.currentStateId];
-  const frames: ElucimStateMachineVisualFrame[] = Object.keys(doc.timelines ?? {}).map(timelineId => ({ timelineId, frame: 0 }));
+  const frames: ElucimStateMachineVisualFrame[] = Object.keys(doc.timelines ?? {}).map(timelineId => ({
+    timelineId,
+    frame: 0,
+    ...(doc.timelines?.[timelineId]?.camera ? { applyCamera: false } : {}),
+  }));
   for (const stateId of path) {
     if (stateId === 'entry') continue;
     const state = machine.states[stateId];
@@ -191,6 +211,7 @@ export function getStateMachineVisualFrames(
     frames.push({
       timelineId: state.timeline,
       frame: stateId === options.currentStateId && !options.exited ? options.currentFrame : timeline.duration,
+      ...(timeline.camera ? { applyCamera: true } : {}),
     });
   }
   return frames;

--- a/packages/dsl/src/documentModel/timeline.ts
+++ b/packages/dsl/src/documentModel/timeline.ts
@@ -1,10 +1,13 @@
 import type {
+  ElucimCamera,
+  ElucimTimelineCamera,
   ElucimDocument,
   ElucimLayout,
   ElucimTimeline,
   ElucimTimelineTrack,
 } from './types';
 import type { EasingSpec } from '../schema/types';
+import { resolveEasing } from '../renderer/resolveEasing';
 
 export interface ElucimTimelinePatch {
   layout?: Partial<ElucimLayout>;
@@ -16,6 +19,8 @@ export type ElucimTimelineFrame = Record<string, ElucimTimelinePatch>;
 export interface ElucimTimelineFrameSelection {
   timelineId: string;
   frame: number;
+  /** Whether this selection may contribute its timeline camera. Default: true. */
+  applyCamera?: boolean;
 }
 
 export function evaluateTimeline(timeline: ElucimTimeline, frame: number): ElucimTimelineFrame {
@@ -48,6 +53,20 @@ export function applyTimelineFrames(doc: ElucimDocument, frames: ElucimTimelineF
   return next;
 }
 
+/** Evaluates the effective camera for ordered timeline selections without mutating the document. */
+export function evaluateTimelineCameraFrames(
+  doc: ElucimDocument,
+  frames: ElucimTimelineFrameSelection[],
+): ElucimCamera | undefined {
+  let camera: ElucimCamera | undefined;
+  for (const { timelineId, frame, applyCamera = true } of frames) {
+    const timeline = doc.timelines?.[timelineId];
+    if (!timeline) throw new Error(`Timeline "${timelineId}" does not exist`);
+    if (timeline.camera && applyCamera) camera = evaluateCameraTrack(timeline.camera, frame);
+  }
+  return camera;
+}
+
 function applyTimelineFrameToDocument(doc: ElucimDocument, timelineId: string, frame: number): void {
   const timeline = doc.timelines?.[timelineId];
   if (!timeline) throw new Error(`Timeline "${timelineId}" does not exist`);
@@ -58,6 +77,42 @@ function applyTimelineFrameToDocument(doc: ElucimDocument, timelineId: string, f
     element.layout = patch.layout ? { ...element.layout, ...patch.layout } : element.layout;
     element.props = patch.props ? { ...element.props, ...patch.props } : element.props;
   }
+}
+
+export function evaluateCameraTrack(track: ElucimTimelineCamera, frame: number): ElucimCamera {
+  const keyframes = [...track.keyframes].sort((a, b) => a.frame - b.frame);
+  if (keyframes.length === 0) throw new Error('Camera track must have at least one keyframe');
+  if (frame <= keyframes[0].frame) {
+    return {
+      viewport: { ...keyframes[0].viewport },
+      ...(track.coordinateSpace ? { coordinateSpace: track.coordinateSpace } : {}),
+      ...(track.fit ? { fit: track.fit } : {}),
+    };
+  }
+  const last = keyframes[keyframes.length - 1];
+  if (frame >= last.frame) {
+    return {
+      viewport: { ...last.viewport },
+      ...(track.coordinateSpace ? { coordinateSpace: track.coordinateSpace } : {}),
+      ...(track.fit ? { fit: track.fit } : {}),
+    };
+  }
+
+  const nextIndex = keyframes.findIndex(keyframe => keyframe.frame >= frame);
+  const from = keyframes[nextIndex - 1];
+  const to = keyframes[nextIndex];
+  const span = to.frame - from.frame;
+  const t = span === 0 ? 1 : ease((frame - from.frame) / span, to.easing ?? from.easing);
+  return {
+    viewport: {
+      x: interpolateNumber(from.viewport.x, to.viewport.x, t),
+      y: interpolateNumber(from.viewport.y, to.viewport.y, t),
+      width: interpolateCameraDimension(from.viewport.width, to.viewport.width, t),
+      height: interpolateCameraDimension(from.viewport.height, to.viewport.height, t),
+    },
+    ...(track.coordinateSpace ? { coordinateSpace: track.coordinateSpace } : {}),
+    ...(track.fit ? { fit: track.fit } : {}),
+  };
 }
 
 function evaluateTrack(track: ElucimTimelineTrack, frame: number): unknown {
@@ -73,6 +128,14 @@ function evaluateTrack(track: ElucimTimelineTrack, frame: number): unknown {
   const span = to.frame - from.frame;
   const t = span === 0 ? 1 : ease((frame - from.frame) / span, to.easing ?? from.easing);
   return interpolateValue(from.value, to.value, t);
+}
+
+function interpolateNumber(from: number, to: number, t: number): number {
+  return from + (to - from) * t;
+}
+
+function interpolateCameraDimension(from: number, to: number, t: number): number {
+  return Math.max(Number.EPSILON, interpolateNumber(from, to, t));
 }
 
 function interpolateValue(from: unknown, to: unknown, t: number): unknown {
@@ -91,31 +154,7 @@ function interpolateValue(from: unknown, to: unknown, t: number): unknown {
 
 function ease(t: number, easing?: EasingSpec): number {
   const clamped = Math.max(0, Math.min(1, t));
-  if (!easing || easing === 'linear') return clamped;
-  if (typeof easing !== 'string') {
-    return easing.type === 'cubicBezier' ? cubicBezierY(clamped, easing.y1, easing.y2) : easeOutCubic(clamped);
-  }
-  switch (easing) {
-    case 'easeInQuad': return clamped * clamped;
-    case 'easeOutQuad': return 1 - (1 - clamped) * (1 - clamped);
-    case 'easeInOutQuad': return clamped < 0.5 ? 2 * clamped * clamped : 1 - Math.pow(-2 * clamped + 2, 2) / 2;
-    case 'easeInCubic': return clamped * clamped * clamped;
-    case 'easeOutCubic': return easeOutCubic(clamped);
-    case 'easeInOutCubic': return clamped < 0.5 ? 4 * clamped * clamped * clamped : 1 - Math.pow(-2 * clamped + 2, 3) / 2;
-    case 'easeInSine': return 1 - Math.cos((clamped * Math.PI) / 2);
-    case 'easeOutSine': return Math.sin((clamped * Math.PI) / 2);
-    case 'easeInOutSine': return -(Math.cos(Math.PI * clamped) - 1) / 2;
-    default: return clamped;
-  }
-}
-
-function easeOutCubic(t: number): number {
-  return 1 - Math.pow(1 - t, 3);
-}
-
-function cubicBezierY(t: number, y1: number, y2: number): number {
-  const inverse = 1 - t;
-  return 3 * inverse * inverse * t * y1 + 3 * inverse * t * t * y2 + t * t * t;
+  return resolveEasing(easing)?.(clamped) ?? clamped;
 }
 
 function parseHexColor(value: unknown): [number, number, number] | undefined {

--- a/packages/dsl/src/documentModel/types.ts
+++ b/packages/dsl/src/documentModel/types.ts
@@ -1,6 +1,17 @@
-import type { ScenePreset, EasingSpec } from '../schema/types';
+import type {
+  CameraNode,
+  CameraTrack,
+  EasingSpec,
+  ScenePreset,
+} from '../schema/types';
 
 export type ElucimVersion = '2.0';
+export type ElucimCamera = CameraNode;
+export type ElucimTimelineCamera = CameraTrack;
+export type ElucimCameraKeyframe = CameraTrack['keyframes'][number];
+export type ElucimCameraViewport = CameraNode['viewport'];
+export type ElucimCameraCoordinateSpace = NonNullable<CameraNode['coordinateSpace']>;
+export type ElucimCameraFit = NonNullable<CameraNode['fit']>;
 
 export interface ElucimDocument {
   $schema?: string;
@@ -103,6 +114,8 @@ export interface ElucimTimeline {
   id: string;
   duration: number;
   tracks: ElucimTimelineTrack[];
+  /** Optional scene-level camera animation for this timeline. */
+  camera?: CameraTrack;
 }
 
 export interface ElucimStateMachine {

--- a/packages/dsl/src/documentModel/validateDocument.ts
+++ b/packages/dsl/src/documentModel/validateDocument.ts
@@ -1,5 +1,6 @@
 import type { ElucimDocument, ElucimElement, ElucimTransition } from './types';
 import type { ValidationError, ValidationResult } from '../validator/validate';
+import { VALID_EASING_NAMES } from '../renderer/resolveEasing';
 
 const VALID_ROOT_TYPES = new Set(['scene', 'player']);
 const VALID_TIMELINE_PROPERTIES = new Set(['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke', 'x', 'dx', 'from', 'to', 'n']);
@@ -30,6 +31,9 @@ export function validateDocument(doc: unknown): ValidationResult {
     }
     if (!Array.isArray(d.scene.children)) {
       errors.push({ path: 'scene.children', message: 'scene.children must be an array of element IDs', severity: 'error' });
+    }
+    if ('camera' in d.scene) {
+      errors.push({ path: 'scene.camera', message: 'Scene camera is not part of Elucim Documents. Use timeline.camera keyframes.', severity: 'error' });
     }
   }
 
@@ -222,6 +226,129 @@ function validateTimelines(doc: ElucimDocument, errors: ValidationError[]) {
         });
       }
     });
+    validateTimelineCamera(timeline.camera, `timelines.${timelineId}.camera`, timeline.duration, errors);
+  }
+}
+
+function validateTimelineCamera(camera: unknown, path: string, duration: number, errors: ValidationError[]) {
+  if (camera === undefined) return;
+  if (!camera || typeof camera !== 'object' || Array.isArray(camera)) {
+    errors.push({ path, message: 'Camera track must be an object', severity: 'error' });
+    return;
+  }
+  const track = camera as Record<string, unknown>;
+  validateCameraOptions(track, path, errors);
+  if (!Array.isArray(track.keyframes) || track.keyframes.length === 0) {
+    errors.push({ path: `${path}.keyframes`, message: 'Camera track must have at least one keyframe', severity: 'error' });
+    return;
+  }
+  let previousFrame = -1;
+  track.keyframes.forEach((keyframe, index) => {
+    const keyframePath = `${path}.keyframes[${index}]`;
+    if (!keyframe || typeof keyframe !== 'object' || Array.isArray(keyframe)) {
+      errors.push({ path: keyframePath, message: 'Camera keyframe must be an object', severity: 'error' });
+      return;
+    }
+    const current = keyframe as Record<string, unknown>;
+    if (!Number.isInteger(current.frame) || (current.frame as number) < 0 || (current.frame as number) > duration) {
+      errors.push({ path: `${keyframePath}.frame`, message: 'Camera keyframe frame must be a non-negative integer within the timeline duration', severity: 'error' });
+    } else if ((current.frame as number) <= previousFrame) {
+      errors.push({ path: `${keyframePath}.frame`, message: 'Camera keyframe frames must be strictly increasing', severity: 'error' });
+    }
+    previousFrame = typeof current.frame === 'number' ? current.frame : previousFrame;
+    validateViewport(current.viewport, `${keyframePath}.viewport`, track.coordinateSpace, errors);
+    validateEasing(current.easing, `${keyframePath}.easing`, errors);
+  });
+}
+
+function validateEasing(easing: unknown, path: string, errors: ValidationError[]) {
+  if (easing === undefined) return;
+  if (typeof easing === 'string') {
+    if (!VALID_EASING_NAMES.includes(easing)) {
+      errors.push({ path, message: `Unknown easing "${easing}". Available: ${VALID_EASING_NAMES.join(', ')}`, severity: 'error' });
+    }
+    return;
+  }
+  if (!easing || typeof easing !== 'object' || Array.isArray(easing)) {
+    errors.push({ path, message: 'Easing must be a string name or { type: "spring"|"cubicBezier", ... }', severity: 'error' });
+    return;
+  }
+  const spec = easing as Record<string, unknown>;
+  if (spec.type === 'spring') {
+    validateOptionalFiniteEasingNumber(spec, 'stiffness', path, errors, true);
+    validateOptionalFiniteEasingNumber(spec, 'damping', path, errors, false);
+    validateOptionalFiniteEasingNumber(spec, 'mass', path, errors, true);
+    return;
+  }
+  if (spec.type === 'cubicBezier') {
+    for (const field of ['x1', 'y1', 'x2', 'y2']) {
+      if (!Number.isFinite(spec[field])) {
+        errors.push({ path: `${path}.${field}`, message: `cubicBezier requires finite numeric "${field}"`, severity: 'error' });
+      }
+    }
+    return;
+  }
+  errors.push({ path: `${path}.type`, message: 'Easing object type must be "spring" or "cubicBezier"', severity: 'error' });
+}
+
+function validateOptionalFiniteEasingNumber(
+  spec: Record<string, unknown>,
+  field: 'stiffness' | 'damping' | 'mass',
+  path: string,
+  errors: ValidationError[],
+  mustBePositive: boolean,
+) {
+  const value = spec[field];
+  if (value === undefined) return;
+  if (!Number.isFinite(value) || (mustBePositive ? (value as number) <= 0 : (value as number) < 0)) {
+    errors.push({
+      path: `${path}.${field}`,
+      message: `${field} must be a finite ${mustBePositive ? 'positive' : 'non-negative'} number`,
+      severity: 'error',
+    });
+  }
+}
+
+function validateCameraOptions(camera: Record<string, unknown>, path: string, errors: ValidationError[]) {
+  if (camera.coordinateSpace !== undefined && camera.coordinateSpace !== 'scene' && camera.coordinateSpace !== 'normalized') {
+    errors.push({ path: `${path}.coordinateSpace`, message: 'coordinateSpace must be "scene" or "normalized"', severity: 'error' });
+  }
+  if (camera.fit !== undefined && camera.fit !== 'cover' && camera.fit !== 'contain') {
+    errors.push({ path: `${path}.fit`, message: 'fit must be "cover" or "contain"', severity: 'error' });
+  }
+}
+
+function validateViewport(viewport: unknown, path: string, coordinateSpace: unknown, errors: ValidationError[]) {
+  if (!viewport || typeof viewport !== 'object' || Array.isArray(viewport)) {
+    errors.push({ path, message: 'Camera viewport must be an object', severity: 'error' });
+    return;
+  }
+  const current = viewport as Record<string, unknown>;
+  for (const key of ['x', 'y', 'width', 'height']) {
+    if (!Number.isFinite(current[key])) {
+      errors.push({ path: `${path}.${key}`, message: `Camera viewport ${key} must be a finite number`, severity: 'error' });
+    }
+  }
+  if (Number.isFinite(current.width) && (current.width as number) <= 0) {
+    errors.push({ path: `${path}.width`, message: 'Camera viewport width must be positive', severity: 'error' });
+  }
+  if (Number.isFinite(current.height) && (current.height as number) <= 0) {
+    errors.push({ path: `${path}.height`, message: 'Camera viewport height must be positive', severity: 'error' });
+  }
+  if (
+    coordinateSpace === 'normalized' &&
+    Number.isFinite(current.x) &&
+    Number.isFinite(current.y) &&
+    Number.isFinite(current.width) &&
+    Number.isFinite(current.height) &&
+    ((current.x as number) < 0 ||
+      (current.y as number) < 0 ||
+      (current.width as number) > 1 ||
+      (current.height as number) > 1 ||
+      (current.x as number) + (current.width as number) > 1 ||
+      (current.y as number) + (current.height as number) > 1)
+  ) {
+    errors.push({ path, message: 'Normalized camera viewport must stay within the unit scene rectangle', severity: 'error' });
   }
 }
 

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -8,6 +8,11 @@ export type {
   ElucimCommandResult,
   ElucimDocument,
   ElucimDocumentSummary,
+  ElucimCamera,
+  ElucimCameraCoordinateSpace,
+  ElucimCameraFit,
+  ElucimCameraKeyframe,
+  ElucimCameraViewport,
   ElucimElement,
   ElucimElementSummary,
   ElucimExportPolicy,
@@ -30,6 +35,7 @@ export type {
   ElucimStateMachineVisualFrameOptions,
   ElucimStateTransitionResult,
   ElucimTimeline,
+  ElucimTimelineCamera,
   ElucimTimelineFrame,
   ElucimTimelineFrameSelection,
   ElucimTimelinePatch,
@@ -78,11 +84,18 @@ export type {
   GraphEdgeDef,
   BarChartNode,
   BarChartBarDef,
+  CameraNode,
+  CameraTrack,
+  CameraKeyframe,
+  CameraViewport,
+  CameraCoordinateSpace,
+  CameraFit,
   ImageNode,
   ScenePreset,
 } from './schema/types';
 
 export { DEFAULT_LINEAR_DURATION_IN_FRAMES } from './documentModel/duration';
+export { SceneCameraViewport, resolveCameraViewport } from './renderer/CameraViewport';
 export { applyCommand } from './documentModel/commands';
 export {
   summarizeDocument,
@@ -92,8 +105,10 @@ export {
 } from './documentModel/services';
 export {
   evaluateTimeline,
+  evaluateCameraTrack,
   applyTimelineFrame,
   applyTimelineFrames,
+  evaluateTimelineCameraFrames,
 } from './documentModel/timeline';
 export {
   getInitialStateSnapshot,

--- a/packages/dsl/src/renderer/CameraViewport.tsx
+++ b/packages/dsl/src/renderer/CameraViewport.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import type { CameraNode } from '../schema/types';
+
+export interface CameraViewportTransform {
+  viewport: { x: number; y: number; width: number; height: number };
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+export interface SceneCameraViewportProps {
+  camera?: CameraNode;
+  width: number;
+  height: number;
+  children: React.ReactNode;
+}
+
+export function resolveCameraViewport(camera: CameraNode, width: number, height: number): CameraViewportTransform {
+  if (
+    !Number.isFinite(camera.viewport.x) ||
+    !Number.isFinite(camera.viewport.y) ||
+    !Number.isFinite(camera.viewport.width) ||
+    !Number.isFinite(camera.viewport.height) ||
+    camera.viewport.width <= 0 ||
+    camera.viewport.height <= 0
+  ) {
+    throw new Error('Camera viewport must have finite coordinates and positive dimensions');
+  }
+  const coordinateScale = camera.coordinateSpace === 'normalized'
+    ? { x: width, y: height }
+    : { x: 1, y: 1 };
+  const viewport = {
+    x: camera.viewport.x * coordinateScale.x,
+    y: camera.viewport.y * coordinateScale.y,
+    width: camera.viewport.width * coordinateScale.x,
+    height: camera.viewport.height * coordinateScale.y,
+  };
+  const fit = camera.fit ?? 'cover';
+  const scale = fit === 'contain'
+    ? Math.min(width / viewport.width, height / viewport.height)
+    : Math.max(width / viewport.width, height / viewport.height);
+  return {
+    viewport,
+    scale,
+    offsetX: (width - viewport.width * scale) / 2,
+    offsetY: (height - viewport.height * scale) / 2,
+  };
+}
+
+/**
+ * Maps scene children through a nested SVG viewport so the crop remains
+ * deterministic in browser, SSR, and SVG export renderers.
+ */
+export function SceneCameraViewport({ camera, width, height, children }: SceneCameraViewportProps) {
+  if (!camera) return <>{children}</>;
+
+  const { viewport } = resolveCameraViewport(camera, width, height);
+  const viewBox = [
+    viewport.x,
+    viewport.y,
+    viewport.width,
+    viewport.height,
+  ].join(' ');
+
+  return (
+    <svg
+      x={0}
+      y={0}
+      width={width}
+      height={height}
+      viewBox={viewBox}
+      preserveAspectRatio={(camera.fit ?? 'cover') === 'contain' ? 'xMidYMid meet' : 'xMidYMid slice'}
+      overflow="hidden"
+      data-elucim-camera-viewport
+    >
+      {children}
+    </svg>
+  );
+}

--- a/packages/dsl/src/renderer/DslRenderer.tsx
+++ b/packages/dsl/src/renderer/DslRenderer.tsx
@@ -1,10 +1,11 @@
 import React, { forwardRef, useImperativeHandle, useMemo, useRef, useSyncExternalStore } from 'react';
 import { validate } from '../validator/validate';
-import type { ElucimDocument as RenderableDocument } from '../schema/types';
+import type { CameraNode, ElucimDocument as RenderableDocument } from '../schema/types';
 import type { ElucimDocument, ElucimTimelineFrameSelection } from '../document';
 import {
   applyTimelineFrames,
   createRenderableDocument,
+  evaluateTimelineCameraFrames,
   getDocumentLinearDuration,
   getInitialStateSnapshot,
   getStateMachineVisualFrames,
@@ -257,9 +258,10 @@ export const DslRenderer = forwardRef<DslRendererRef, DslRendererProps>(function
       : themeWithCompatibilityAliases(theme),
   ) as React.CSSProperties;
 
-  const posterRenderableDsl = poster !== undefined ? resolvePosterRenderableDsl(poster, dsl) : undefined;
-  const renderableDsl = stateMachineRuntime.renderableDsl ?? posterRenderableDsl ?? toRenderableDocument(dsl);
-  const posterOverrides = poster !== undefined && posterRenderableDsl === undefined ? resolvePoster(poster, renderableDsl) : undefined;
+  const posterProjection = poster !== undefined ? resolvePosterRenderableDsl(poster, dsl) : undefined;
+  const renderableDsl = stateMachineRuntime.renderableDsl ?? posterProjection?.document ?? toRenderableDocument(dsl);
+  const camera = stateMachineRuntime.camera ?? posterProjection?.camera;
+  const posterOverrides = poster !== undefined && posterProjection === undefined ? resolvePoster(poster, renderableDsl) : undefined;
   const rootOverrides = stateMachineRuntime.enabled ? { frame: stateMachineRuntime.frameOverride } : posterOverrides;
 
   const content = renderRoot(renderableDsl.root, {
@@ -271,6 +273,7 @@ export const DslRenderer = forwardRef<DslRendererRef, DslRendererProps>(function
     loop,
     fitToContainer,
     onPlayStateChange,
+    camera,
   });
 
   const inner = (
@@ -301,12 +304,15 @@ function resolvePoster(poster: 'first' | 'last' | number, dsl: RenderableDocumen
   return { frame: poster };
 }
 
-function resolvePosterRenderableDsl(poster: 'first' | 'last' | number, dsl: ElucimDocument | RenderableDocument): RenderableDocument | undefined {
+function resolvePosterRenderableDsl(
+  poster: 'first' | 'last' | number,
+  dsl: ElucimDocument | RenderableDocument,
+): { document: RenderableDocument; camera?: CameraNode } | undefined {
   if (dsl.version !== '2.0') return undefined;
   const frame = resolveDocumentPosterFrame(poster, dsl);
   const frames = getPosterTimelineFrames(dsl, frame);
   const posterDoc = frames.length > 0 ? applyTimelineFrames(dsl, frames) : dsl;
-  return createRenderableDocument(posterDoc);
+  return { document: createRenderableDocument(posterDoc), camera: evaluateTimelineCameraFrames(dsl, frames) };
 }
 
 function resolveDocumentPosterFrame(poster: 'first' | 'last' | number, dsl: ElucimDocument): number {

--- a/packages/dsl/src/renderer/renderElements.tsx
+++ b/packages/dsl/src/renderer/renderElements.tsx
@@ -14,6 +14,8 @@ import type { TransitionType, PlayerRef } from '@elucim/core';
 import { resolveEasing } from './resolveEasing';
 import { resolveColor } from './resolveColor';
 import { compileExpression, compileVectorExpression } from '../math/evaluator';
+import { SceneCameraViewport } from './CameraViewport';
+import type { CameraNode } from '../schema/types';
 
 // ─── Preset dimensions ─────────────────────────────────────────────────────
 
@@ -47,6 +49,8 @@ export interface RenderRootOverrides {
   fitToContainer?: boolean;
   /** Callback fired when playback state changes. */
   onPlayStateChange?: (playing: boolean) => void;
+  /** Evaluated camera from the active timeline or state-machine path. */
+  camera?: CameraNode;
 }
 
 export function renderRoot(
@@ -82,6 +86,8 @@ export function renderRoot(
 export function renderScene(node: SceneNode, overrides?: RenderRootOverrides): React.ReactNode {
   const hasFrameOverride = overrides?.frame !== undefined;
   const { width, height } = resolvePreset(node.preset, node.width, node.height);
+  const sceneWidth = width ?? 1920;
+  const sceneHeight = height ?? 1080;
   return (
     <Scene
       width={width}
@@ -93,13 +99,17 @@ export function renderScene(node: SceneNode, overrides?: RenderRootOverrides): R
       fitToContainer={overrides?.fitToContainer}
       {...(hasFrameOverride ? { frame: overrides!.frame, autoPlay: false } : {})}
     >
-      {node.children.map((child, i) => renderElement(child, i))}
+      <SceneCameraViewport camera={overrides?.camera} width={sceneWidth} height={sceneHeight}>
+        {node.children.map((child, i) => renderElement(child, i))}
+      </SceneCameraViewport>
     </Scene>
   );
 }
 
 export function renderPlayer(node: PlayerNode, overrides?: RenderRootOverrides): React.ReactNode {
   const { width, height } = resolvePreset(node.preset, node.width, node.height);
+  const sceneWidth = width ?? 1920;
+  const sceneHeight = height ?? 1080;
   return (
     <Player
       ref={overrides?.playerRef as React.Ref<PlayerRef> | undefined}
@@ -115,7 +125,9 @@ export function renderPlayer(node: PlayerNode, overrides?: RenderRootOverrides):
       fitToContainer={overrides?.fitToContainer}
       colorScheme={overrides?.colorScheme}
     >
-      {node.children.map((child, i) => renderElement(child, i))}
+      <SceneCameraViewport camera={overrides?.camera} width={sceneWidth} height={sceneHeight}>
+        {node.children.map((child, i) => renderElement(child, i))}
+      </SceneCameraViewport>
     </Player>
   );
 }

--- a/packages/dsl/src/renderer/renderToPng.ts
+++ b/packages/dsl/src/renderer/renderToPng.ts
@@ -31,6 +31,8 @@ export interface RenderToPngOptions {
   height?: number;
   /** Device pixel ratio for retina output (default: 2) */
   scale?: number;
+  /** Canonical timeline to evaluate before rendering this frame. */
+  timelineId?: string;
 }
 
 /**
@@ -67,6 +69,7 @@ export async function renderToPng(
   const htmlString = renderToSvgString(dsl, frame, {
     width: options?.width,
     height: options?.height,
+    timelineId: options?.timelineId,
   });
 
   // 2. Extract the <svg>...</svg> element (Scene wraps SVG in a <div>)

--- a/packages/dsl/src/renderer/renderToSvgString.ts
+++ b/packages/dsl/src/renderer/renderToSvgString.ts
@@ -2,13 +2,16 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import React from 'react';
 import { renderRoot } from './renderElements';
 import { validate } from '../validator/validate';
-import { toRenderableDocument } from '../document';
+import { applyTimelineFrame, createRenderableDocument, evaluateTimelineCameraFrames, toRenderableDocument } from '../document';
+import { applyDefaultStateMachineInitialFrame } from '../documentModel/compatibility';
 import type { ElucimDocument as RenderableDocument } from '../schema/types';
 import type { ElucimDocument } from '../document';
 
 export interface RenderToSvgStringOptions {
   width?: number;
   height?: number;
+  /** Canonical timeline to evaluate before rendering this frame. */
+  timelineId?: string;
 }
 
 /**
@@ -31,7 +34,16 @@ export function renderToSvgString(
     );
   }
 
-  const renderable = toRenderableDocument(dsl);
+  const camera = dsl.version === '2.0' && options?.timelineId
+    ? evaluateTimelineCameraFrames(dsl, [{ timelineId: options.timelineId, frame }])
+    : undefined;
+  const renderable = dsl.version === '2.0'
+    ? createRenderableDocument(
+      options?.timelineId
+        ? applyTimelineFrame(applyDefaultStateMachineInitialFrame(dsl), options.timelineId, frame)
+        : applyDefaultStateMachineInitialFrame(dsl),
+    )
+    : toRenderableDocument(dsl);
 
   // Clone the root and apply size overrides
   const root = { ...renderable.root };
@@ -39,7 +51,7 @@ export function renderToSvgString(
   if (options?.height) root.height = options.height;
 
   // Render the tree with a controlled frame override
-  const element = renderRoot(root, { frame });
+  const element = renderRoot(root, { frame, camera });
 
   return renderToStaticMarkup(element as React.ReactElement);
 }

--- a/packages/dsl/src/renderer/useStateMachineRuntime.ts
+++ b/packages/dsl/src/renderer/useStateMachineRuntime.ts
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import type { ElucimDocument as RenderableDocument } from '../schema/types';
+import type { CameraNode, ElucimDocument as RenderableDocument } from '../schema/types';
 import type { ElucimDocument, ElucimStateMachineRun } from '../document';
 import {
   advanceStateMachineRunFrame,
   applyTimelineFrames,
   createRenderableDocument,
   dispatchStateMachineRunEvent,
+  evaluateTimelineCameraFrames,
   getStateMachineRunVisualFrames,
   startStateMachineRun,
 } from '../document';
@@ -21,6 +22,7 @@ interface StateMachineRuntimeOptions {
 interface StateMachineRuntime {
   enabled: boolean;
   renderableDsl?: RenderableDocument;
+  camera?: CameraNode;
   frameOverride?: number;
   getTotalFrames(): number;
   seekToFrame(frame: number): void;
@@ -97,7 +99,7 @@ export function useStateMachineRuntime({
     return () => cancelAnimationFrame(raf);
   }, [effectiveRun?.playing, enabled, onPlayStateChange, shouldLoop, stateMachineDocument, stateMachineId]);
 
-  const renderableDsl = enabled && stateMachineDocument && effectiveRun
+  const renderProjection = enabled && stateMachineDocument && effectiveRun
     ? stateMachineRunToRenderableDocument(stateMachineDocument, effectiveRun)
     : undefined;
 
@@ -121,7 +123,8 @@ export function useStateMachineRuntime({
 
   return {
     enabled,
-    renderableDsl,
+    renderableDsl: renderProjection?.document,
+    camera: renderProjection?.camera,
     frameOverride: enabled ? 0 : undefined,
     getTotalFrames: () => effectiveRun ? getRunDuration(stateMachineDocument, effectiveRun) + 1 : 0,
     seekToFrame: frame => {
@@ -157,9 +160,15 @@ function getStateMachineDocument(dsl: RenderableDocument | ElucimDocument): Eluc
   return dsl.version === '2.0' && dsl.defaultStateMachine ? dsl : undefined;
 }
 
-function stateMachineRunToRenderableDocument(doc: ElucimDocument, run: ElucimStateMachineRun): RenderableDocument {
+function stateMachineRunToRenderableDocument(
+  doc: ElucimDocument,
+  run: ElucimStateMachineRun,
+): { document: RenderableDocument; camera?: CameraNode } {
   const frames = getStateMachineRunVisualFrames(doc, run);
-  return createRenderableDocument(frames.length > 0 ? applyTimelineFrames(doc, frames) : doc);
+  return {
+    document: createRenderableDocument(frames.length > 0 ? applyTimelineFrames(doc, frames) : doc),
+    camera: evaluateTimelineCameraFrames(doc, frames),
+  };
 }
 
 function getRunDuration(doc: ElucimDocument | undefined, run: ElucimStateMachineRun): number {

--- a/packages/dsl/src/schema/types.ts
+++ b/packages/dsl/src/schema/types.ts
@@ -18,6 +18,41 @@ export type RootNode = SceneNode | PlayerNode | PresentationNode;
 /** Preset dimensions for common scene sizes */
 export type ScenePreset = 'card' | 'slide' | 'square';
 
+/** Coordinates of the scene region viewed by a camera. */
+export interface CameraViewport {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Coordinate system used by a camera viewport. */
+export type CameraCoordinateSpace = 'scene' | 'normalized';
+
+/** How a camera viewport is mapped onto the scene surface. */
+export type CameraFit = 'cover' | 'contain';
+
+/** An evaluated timeline camera viewport used only while rendering. */
+export interface CameraNode {
+  viewport: CameraViewport;
+  coordinateSpace?: CameraCoordinateSpace;
+  fit?: CameraFit;
+}
+
+/** A frame-accurate camera viewport sample. */
+export interface CameraKeyframe {
+  frame: number;
+  viewport: CameraViewport;
+  easing?: EasingSpec;
+}
+
+/** A semantic scene camera animation owned by a normalized timeline. */
+export interface CameraTrack {
+  coordinateSpace?: CameraCoordinateSpace;
+  fit?: CameraFit;
+  keyframes: CameraKeyframe[];
+}
+
 // ─── Container Nodes ────────────────────────────────────────────────────────
 
 export interface SceneNode {

--- a/packages/dsl/src/validator/validate.ts
+++ b/packages/dsl/src/validator/validate.ts
@@ -88,6 +88,9 @@ function validateContainerNode(node: Record<string, unknown>, path: string, type
   optionalPositiveNum(node, 'height', path, errors);
   optionalPositiveNum(node, 'fps', path, errors);
   optionalString(node, 'background', path, errors);
+  if ('camera' in node) {
+    errors.push({ path: `${path}.camera`, message: 'Render-tree camera is not supported. Use timeline.camera keyframes in an Elucim Document.', severity: 'error' });
+  }
 
   if (node.preset !== undefined) {
     if (typeof node.preset !== 'string' || !VALID_PRESETS.includes(node.preset)) {

--- a/packages/e2e/tests/scene-camera.spec.ts
+++ b/packages/e2e/tests/scene-camera.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test } from '@playwright/test';
+
+const CAMERA_DOCUMENT = {
+  version: '2.0',
+  scene: {
+    type: 'player',
+    width: 800,
+    height: 600,
+    children: ['focus', 'focus-label'],
+  },
+  elements: {
+    focus: {
+      id: 'focus',
+      type: 'rect',
+      props: { type: 'rect', x: 200, y: 150, width: 400, height: 300, fill: '#4fc3f7' },
+    },
+    'focus-label': {
+      id: 'focus-label',
+      type: 'text',
+      props: { type: 'text', x: 300, y: 260, content: 'Focus label', fontSize: 32, fill: '#001018' },
+    },
+  },
+  timelines: {
+    focus: {
+      id: 'focus',
+      duration: 120,
+      tracks: [{ target: 'focus', property: 'opacity', keyframes: [{ frame: 0, value: 1 }] }],
+      camera: {
+        coordinateSpace: 'scene',
+        fit: 'cover',
+        keyframes: [{ frame: 0, viewport: { x: 200, y: 150, width: 400, height: 300 } }],
+      },
+    },
+  },
+};
+
+const CAMERALESS_DOCUMENT = {
+  ...CAMERA_DOCUMENT,
+  timelines: undefined,
+};
+
+const TIMELINE_CAMERA_DOCUMENT = CAMERA_DOCUMENT;
+
+const TIMELINE_CAMERALESS_DOCUMENT = {
+  ...CAMERA_DOCUMENT,
+  timelines: {
+    focus: {
+      ...CAMERA_DOCUMENT.timelines.focus,
+      camera: undefined,
+    },
+  },
+};
+
+test('renders a normalized scene camera in the editor canvas', async ({ page }) => {
+  await page.addInitScript(({ key, document }) => {
+    window.localStorage.setItem(key, JSON.stringify(document));
+  }, { key: 'scene-camera-e2e', document: CAMERA_DOCUMENT });
+
+  await page.goto('/editor.html?document=localStorage&docKey=scene-camera-e2e');
+  await expect(page.locator('.elucim-editor')).toBeVisible({ timeout: 15000 });
+
+  const cameraViewports = page.locator('.elucim-editor-canvas [data-elucim-camera-viewport]');
+  await expect(cameraViewports).toHaveCount(2);
+  await expect(cameraViewports.first()).toHaveAttribute('viewBox', '200 150 400 300');
+  await expect(cameraViewports.first()).toBeVisible();
+});
+
+test('keeps inline text editing aligned with a camera crop', async ({ page }) => {
+  await page.addInitScript(({ key, document }) => {
+    window.localStorage.setItem(key, JSON.stringify(document));
+  }, { key: 'scene-camera-inline-edit', document: CAMERA_DOCUMENT });
+
+  await page.goto('/editor.html?document=localStorage&docKey=scene-camera-inline-edit');
+  await expect(page.locator('.elucim-editor')).toBeVisible({ timeout: 15000 });
+
+  const text = page.locator('text').filter({ hasText: 'Focus label' });
+  const textBounds = await text.boundingBox();
+  if (!textBounds) throw new Error('Camera test text did not render');
+  await page.mouse.click(textBounds.x + textBounds.width / 2, textBounds.y + textBounds.height / 2);
+  await expect(page.getByRole('treeitem', { name: /focus-label/ })).toHaveAttribute('aria-selected', 'true');
+  await page.keyboard.press('Enter');
+
+  const editor = page.getByRole('textbox', { name: 'Edit text on canvas' });
+  await expect(editor).toBeVisible();
+  const editorBounds = await editor.boundingBox();
+  if (!editorBounds) throw new Error('Inline text editor did not render');
+
+  expect(Math.abs(editorBounds.x - textBounds.x)).toBeLessThan(20);
+});
+
+test('authors a camera viewport from the visual framing controls', async ({ page }) => {
+  await page.addInitScript(({ key, document }) => {
+    window.localStorage.setItem(key, JSON.stringify(document));
+  }, { key: 'scene-camera-framing', document: TIMELINE_CAMERA_DOCUMENT });
+
+  await page.goto('/editor.html?document=localStorage&docKey=scene-camera-framing');
+  await expect(page.locator('.elucim-editor')).toBeVisible({ timeout: 15000 });
+  await page.getByRole('button', { name: 'Canvas scene' }).click();
+  await page.getByRole('button', { name: 'Show Inspector' }).click();
+  await page.getByRole('button', { name: 'Frame timeline camera' }).click();
+
+  await expect(page.getByLabel('Camera framing controls')).toBeVisible();
+  await expect(page.getByTestId('camera-frame-handle-se')).toBeVisible();
+  await page.locator('[role="treeitem"]').filter({ hasText: 'focusrect' }).click();
+  const focusSelection = page.getByRole('button', { name: 'Focus selection' });
+  await expect(focusSelection).toBeEnabled();
+  await focusSelection.click();
+  await page.getByRole('button', { name: 'Done' }).click();
+
+  await expect(page.getByLabel('Camera framing controls')).toHaveCount(0);
+  await expect(page.locator('.elucim-editor-canvas [data-elucim-camera-viewport]').first())
+    .not.toHaveAttribute('viewBox', '200 150 400 300');
+});
+
+test('authors a camera viewport by drawing a frame', async ({ page }) => {
+  await page.addInitScript(({ key, document }) => {
+    window.localStorage.setItem(key, JSON.stringify(document));
+  }, { key: 'scene-camera-draw-frame', document: TIMELINE_CAMERA_DOCUMENT });
+
+  await page.goto('/editor.html?document=localStorage&docKey=scene-camera-draw-frame');
+  await expect(page.locator('.elucim-editor')).toBeVisible({ timeout: 15000 });
+  await page.getByRole('button', { name: 'Canvas scene' }).click();
+  await page.getByRole('button', { name: 'Show Inspector' }).click();
+  await page.getByRole('button', { name: 'Frame timeline camera' }).click();
+
+  await page.getByRole('button', { name: 'Draw frame' }).click();
+  const drawSurface = page.getByTestId('camera-frame-draw-surface');
+  const bounds = await drawSurface.boundingBox();
+  if (!bounds) throw new Error('Camera draw surface did not render');
+
+  await page.mouse.move(bounds.x + bounds.width * 0.1, bounds.y + bounds.height * 0.15);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + bounds.width * 0.55, bounds.y + bounds.height * 0.6);
+  await page.mouse.up();
+  await page.getByRole('button', { name: 'Done' }).click();
+
+  await expect(page.getByLabel('Camera framing controls')).toHaveCount(0);
+  await expect(page.locator('.elucim-editor-canvas [data-elucim-camera-viewport]').first())
+    .not.toHaveAttribute('viewBox', '200 150 400 300');
+});
+
+test('does not create a camera when a new frame is canceled', async ({ page }) => {
+  await page.addInitScript(({ key, document }) => {
+    window.localStorage.setItem(key, JSON.stringify(document));
+  }, { key: 'scene-camera-cancel-frame', document: TIMELINE_CAMERALESS_DOCUMENT });
+
+  await page.goto('/editor.html?document=localStorage&docKey=scene-camera-cancel-frame');
+  await expect(page.locator('.elucim-editor')).toBeVisible({ timeout: 15000 });
+  await page.getByRole('button', { name: 'Canvas scene' }).click();
+  await page.getByRole('button', { name: 'Show Inspector' }).click();
+  await page.getByRole('button', { name: 'Frame timeline camera' }).click();
+
+  await expect(page.getByLabel('Camera framing controls')).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect(page.getByLabel('Camera framing controls')).toHaveCount(0);
+  await expect(page.locator('.elucim-editor-canvas [data-elucim-camera-viewport]')).toHaveCount(0);
+});

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -89,6 +89,7 @@ function App() {
 - **Minimap** for orientation in large scenes
 - **Zoom controls** with zoom-to-fit
 - Canvas itself is selectable — click empty space to edit scene properties (dimensions, background, FPS, duration)
+- **Camera framing** — draw and resize a crop rectangle, lock its aspect ratio, focus the current selection, then commit a keyframe to the selected timeline
 
 ### 🧰 Toolbar
 

--- a/packages/editor/src/__tests__/cameraFraming.test.ts
+++ b/packages/editor/src/__tests__/cameraFraming.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  constrainCameraFrame,
+  focusCameraFrame,
+  getSceneCameraViewport,
+  resizeCameraFrame,
+  toCameraViewport,
+} from '../canvas/CameraFramingOverlay';
+
+describe('camera framing geometry', () => {
+  it('converts normalized cameras to and from scene coordinates', () => {
+    const viewport = getSceneCameraViewport({
+      coordinateSpace: 'normalized',
+      viewport: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+    }, 800, 600);
+
+    expect(viewport).toEqual({ x: 200, y: 150, width: 400, height: 300 });
+    expect(toCameraViewport(viewport, 'normalized', 800, 600)).toEqual({
+      x: 0.25,
+      y: 0.25,
+      width: 0.5,
+      height: 0.5,
+    });
+  });
+
+  it('keeps a focused selection visible while matching the scene aspect ratio', () => {
+    const viewport = focusCameraFrame({ x: 300, y: 220, width: 120, height: 80 }, 800, 600, 24);
+
+    expect(viewport.width / viewport.height).toBeCloseTo(800 / 600);
+    expect(viewport.x).toBeLessThanOrEqual(300);
+    expect(viewport.y).toBeLessThanOrEqual(220);
+    expect(viewport.x + viewport.width).toBeGreaterThanOrEqual(420);
+    expect(viewport.y + viewport.height).toBeGreaterThanOrEqual(300);
+  });
+
+  it('constrains framing rectangles to positive dimensions within the scene', () => {
+    expect(constrainCameraFrame({ x: -20, y: 590, width: 900, height: 40 }, 800, 600))
+      .toEqual({ x: 0, y: 560, width: 800, height: 40 });
+  });
+
+  it('keeps the opposite edge fixed when a free-aspect resize reaches a scene boundary', () => {
+    expect(resizeCameraFrame(
+      { x: 100, y: 100, width: 400, height: 300 },
+      'e',
+      500,
+      0,
+      800,
+      600,
+      false,
+    )).toEqual({ x: 100, y: 100, width: 700, height: 300 });
+  });
+
+  it('keeps anchored edges fixed when an aspect-locked resize reaches a scene boundary', () => {
+    expect(resizeCameraFrame(
+      { x: 100, y: 150, width: 400, height: 300 },
+      'se',
+      500,
+      500,
+      800,
+      600,
+      true,
+    )).toEqual({ x: 100, y: 150, width: 600, height: 450 });
+  });
+});

--- a/packages/editor/src/__tests__/cameraKeyframes.test.ts
+++ b/packages/editor/src/__tests__/cameraKeyframes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { upsertTimelineCameraKeyframe } from '../timeline/cameraKeyframes';
+
+describe('upsertTimelineCameraKeyframe', () => {
+  it('replaces a timeline keyframe in the timeline coordinate space', () => {
+    const timeline = {
+      id: 'focus',
+      duration: 60,
+      tracks: [],
+      camera: {
+        coordinateSpace: 'normalized' as const,
+        fit: 'contain' as const,
+        keyframes: [{ frame: 20, viewport: { x: 0, y: 0, width: 1, height: 1 } }],
+      },
+    };
+
+    const next = upsertTimelineCameraKeyframe(
+      timeline,
+      undefined,
+      20,
+      { x: 160, y: 120, width: 320, height: 240 },
+      800,
+      600,
+    );
+
+    expect(next.camera).toEqual({
+      coordinateSpace: 'normalized',
+      fit: 'contain',
+      keyframes: [{ frame: 20, viewport: { x: 0.2, y: 0.2, width: 0.4, height: 0.4 } }],
+    });
+  });
+
+  it('clamps a new keyframe to the timeline duration', () => {
+    const next = upsertTimelineCameraKeyframe(
+      { id: 'focus', duration: 30, tracks: [] },
+      undefined,
+      40,
+      { x: 0, y: 0, width: 800, height: 600 },
+      800,
+      600,
+    );
+
+    expect(next.camera?.keyframes).toEqual([
+      { frame: 30, viewport: { x: 0, y: 0, width: 800, height: 600 } },
+    ]);
+  });
+});

--- a/packages/editor/src/__tests__/editorTimelinePanel.test.ts
+++ b/packages/editor/src/__tests__/editorTimelinePanel.test.ts
@@ -6,6 +6,7 @@ import {
   applyTimelineDocumentChange,
   getPreferredMotionType,
 } from '../timeline/EditorTimelinePanel';
+import { clampTimelineKeyframesToDuration, previewFramesEqual } from '../timeline/Timeline';
 
 const timeline: ElucimTimeline = {
   id: 'intro',
@@ -57,6 +58,52 @@ describe('editor timeline panel helpers', () => {
     expect(next.timelines?.intro.duration).toBe(60);
     expect(next.stateMachines?.deck.states.complete).toEqual({});
     expect(next.elements).toBe(document.elements);
+  });
+
+  it('preserves camera-only timelines', () => {
+    const cameraTimeline: ElucimTimeline = {
+      id: 'camera',
+      duration: 30,
+      tracks: [],
+      camera: {
+        keyframes: [{ frame: 0, viewport: { x: 0, y: 0, width: 800, height: 600 } }],
+      },
+    };
+
+    const next = applyTimelineDocumentChange(document, { camera: cameraTimeline });
+
+    expect(next.timelines?.camera.camera?.keyframes).toHaveLength(1);
+  });
+
+  it('coalesces camera keyframes when a timeline duration is reduced', () => {
+    const next = clampTimelineKeyframesToDuration({
+      id: 'camera',
+      duration: 30,
+      tracks: [],
+      camera: {
+        keyframes: [
+          { frame: 0, viewport: { x: 0, y: 0, width: 800, height: 600 } },
+          { frame: 20, viewport: { x: 100, y: 75, width: 400, height: 300 } },
+          { frame: 30, viewport: { x: 200, y: 150, width: 200, height: 150 } },
+        ],
+      },
+    }, 10);
+
+    expect(next.camera?.keyframes).toEqual([
+      { frame: 0, viewport: { x: 0, y: 0, width: 800, height: 600 } },
+      { frame: 10, viewport: { x: 200, y: 150, width: 200, height: 150 } },
+    ]);
+  });
+
+  it('refreshes state-machine preview frames when camera application changes', () => {
+    expect(previewFramesEqual(
+      [{ timelineId: 'inactive', frame: 0 }],
+      [{ timelineId: 'inactive', frame: 0, applyCamera: false }],
+    )).toBe(false);
+    expect(previewFramesEqual(
+      [{ timelineId: 'inactive', frame: 0 }],
+      [{ timelineId: 'inactive', frame: 0, applyCamera: true }],
+    )).toBe(true);
   });
 
   it('selects the state-machine motion tab only for the state-machine workspace', () => {

--- a/packages/editor/src/__tests__/inspector.test.ts
+++ b/packages/editor/src/__tests__/inspector.test.ts
@@ -77,6 +77,60 @@ describe('inspector position updates', () => {
     expect(el.cy).toBe(200); // unchanged
   });
 
+  describe('canvas camera inspector', () => {
+    it('starts camera framing for the selected timeline', async () => {
+      let latestFraming = false;
+      let latestTimelineId: string | undefined;
+
+      function SelectTimeline() {
+        const { state, dispatch } = useEditorState();
+        useEffect(() => {
+          dispatch({ type: 'SET_ACTIVE_TIMELINE', timelineId: 'intro' });
+        }, [dispatch]);
+        useEffect(() => {
+          latestFraming = state.isCameraFraming;
+          latestTimelineId = state.cameraFramingTimelineId;
+        }, [state.cameraFramingTimelineId, state.isCameraFraming]);
+        return null;
+      }
+
+      render(
+        React.createElement(
+          EditorProvider,
+          {
+            initialDocument: {
+              version: 'render-tree',
+              root: {
+                type: 'player',
+                width: 800,
+                height: 600,
+                durationInFrames: 120,
+                children: [],
+              },
+            },
+            initialCanonicalDocument: {
+              version: '2.0',
+              scene: { type: 'player', width: 800, height: 600, children: [] },
+              elements: {},
+              timelines: {
+                intro: { id: 'intro', duration: 120, tracks: [] },
+              },
+            },
+          },
+          React.createElement(SelectTimeline),
+          React.createElement(Inspector),
+        ),
+      );
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Frame timeline camera' }));
+
+      await waitFor(() => {
+        expect(latestFraming).toBe(true);
+        expect(latestTimelineId).toBe('intro');
+      });
+    });
+  });
+
   it('updates rect x/y/width/height', () => {
     let state = stateWith(rect);
     state = editorReducer(state, { type: 'UPDATE_ELEMENT', id: 'r1', changes: { width: 200, height: 150 } as any });

--- a/packages/editor/src/__tests__/keyboard.test.tsx
+++ b/packages/editor/src/__tests__/keyboard.test.tsx
@@ -23,11 +23,13 @@ afterEach(() => {
 function KeyboardHarness({
   isPlaying,
   isCanvasHovered = false,
+  isCameraFraming = false,
   dispatch,
   selectedIds = [],
 }: {
   isPlaying: boolean;
   isCanvasHovered?: boolean;
+  isCameraFraming?: boolean;
   dispatch: React.Dispatch<EditorAction>;
   selectedIds?: string[];
 }) {
@@ -38,6 +40,7 @@ function KeyboardHarness({
     zoom: 1,
     isPlaying,
     isCanvasHovered,
+    isCameraFraming,
     getDocumentJson: () => JSON.stringify(testDocument),
     importDocument: () => {},
   });
@@ -82,6 +85,17 @@ describe('keyboard shortcuts', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete' }));
 
     expect(dispatch).toHaveBeenCalledWith({ type: 'DELETE_ELEMENTS', ids: ['rect-1'] });
+  });
+
+  it('reserves keyboard input for camera framing and cancels it with Escape', () => {
+    const dispatch = vi.fn();
+    render(<KeyboardHarness isPlaying={false} isCameraFraming selectedIds={['rect-1']} dispatch={dispatch} />);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete' }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(dispatch).not.toHaveBeenCalledWith({ type: 'DELETE_ELEMENTS', ids: ['rect-1'] });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CAMERA_FRAMING', framing: false });
   });
 
   it('focuses the canvas on pointer down so stale form focus does not trap Delete', () => {

--- a/packages/editor/src/__tests__/marquee.test.ts
+++ b/packages/editor/src/__tests__/marquee.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { screenToMarqueeScene } from '../canvas/useMarquee';
+
+describe('camera-aware marquee coordinates', () => {
+  it('maps a cropped camera viewport back to logical scene coordinates', () => {
+    const rect = { left: 0, top: 0, width: 800, height: 600 } as DOMRect;
+    const viewport = { x: 0, y: 0, zoom: 1 };
+    const camera = {
+      coordinateSpace: 'scene' as const,
+      fit: 'cover' as const,
+      viewport: { x: 200, y: 150, width: 400, height: 300 },
+    };
+
+    expect(screenToMarqueeScene(400, 300, rect, viewport, 800, 600, camera)).toEqual({ x: 400, y: 300 });
+  });
+});

--- a/packages/editor/src/__tests__/reducer.test.ts
+++ b/packages/editor/src/__tests__/reducer.test.ts
@@ -81,6 +81,7 @@ describe('createInitialState', () => {
     expect(state.future).toEqual([]);
     expect(state.currentFrame).toBe(0);
     expect(state.isPlaying).toBe(false);
+    expect(state.isCameraFraming).toBe(false);
     expect(state.activeTool).toBe('select');
     expect(state.document.version).toBe('render-tree');
     expect((state.document.root as any).width).toBe(1920);
@@ -133,6 +134,52 @@ describe('selection actions', () => {
     const state = stateWithElements(circle1, rect1);
     const next = editorReducer(state, { type: 'SELECT', ids: ['c1'] });
     expect(next.selectedIds).toEqual(['c1']);
+  });
+
+  describe('camera framing action', () => {
+    it('toggles framing mode without creating an undo history entry', () => {
+      const state = stateWithElements(circle1);
+      const next = editorReducer(state, { type: 'SET_CAMERA_FRAMING', framing: true, timelineId: 'focus' });
+
+      expect(next.isCameraFraming).toBe(true);
+      expect(next.cameraFramingTimelineId).toBe('focus');
+      expect(next.past).toEqual([]);
+      const complete = editorReducer(next, { type: 'SET_CAMERA_FRAMING', framing: false });
+      expect(complete.isCameraFraming).toBe(false);
+      expect(complete.cameraFramingTimelineId).toBeUndefined();
+    });
+
+    it('tracks the timeline selected by motion authoring', () => {
+      const next = editorReducer(stateWithElements(circle1), { type: 'SET_ACTIVE_TIMELINE', timelineId: 'focus' });
+
+      expect(next.activeTimelineId).toBe('focus');
+    });
+
+    it('captures the framing playhead and applies timeline camera edits as one undoable action', () => {
+      let state = stateWithCanonicalDocument();
+      state = editorReducer(state, { type: 'SET_CAMERA_FRAMING', framing: true, timelineId: 'intro', frame: 12 });
+
+      expect(state.cameraFramingFrame).toBe(12);
+
+      state = editorReducer(state, {
+        type: 'UPDATE_TIMELINE_CAMERA',
+        timelineId: 'intro',
+        camera: {
+          keyframes: [{ frame: 12, viewport: { x: 80, y: 60, width: 400, height: 300 } }],
+        },
+      });
+      expect(state.canonicalDocument?.timelines?.intro.camera?.keyframes).toEqual([
+        { frame: 12, viewport: { x: 80, y: 60, width: 400, height: 300 } },
+      ]);
+
+      state = editorReducer(state, { type: 'UNDO' });
+      expect(state.canonicalDocument?.timelines?.intro.camera).toBeUndefined();
+
+      state = editorReducer(state, { type: 'REDO' });
+      expect(state.canonicalDocument?.timelines?.intro.camera?.keyframes).toEqual([
+        { frame: 12, viewport: { x: 80, y: 60, width: 400, height: 300 } },
+      ]);
+    });
   });
 
   it('SELECT_ADD adds to selection', () => {

--- a/packages/editor/src/canvas/CameraFramingOverlay.tsx
+++ b/packages/editor/src/canvas/CameraFramingOverlay.tsx
@@ -1,0 +1,369 @@
+import React, { useCallback, useRef } from 'react';
+import { v } from '../theme/tokens';
+import { startRafDrag, type RafDragPoint } from '../interactions/rafDrag';
+
+export interface CameraFrameViewport {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CameraFramingOverlayProps {
+  viewport: CameraFrameViewport;
+  sceneWidth: number;
+  sceneHeight: number;
+  aspectLocked: boolean;
+  drawing: boolean;
+  onViewportChange: (viewport: CameraFrameViewport) => void;
+  onViewportCommit: (viewport: CameraFrameViewport) => void;
+  onDrawingComplete: () => void;
+}
+
+const MIN_CAMERA_SIZE = 1;
+const HANDLE_SIZE = 10;
+
+export function getSceneCameraViewport(
+  camera: { viewport: CameraFrameViewport; coordinateSpace?: 'scene' | 'normalized' } | undefined,
+  sceneWidth: number,
+  sceneHeight: number,
+): CameraFrameViewport {
+  if (!camera) return { x: 0, y: 0, width: sceneWidth, height: sceneHeight };
+  const scaleX = camera.coordinateSpace === 'normalized' ? sceneWidth : 1;
+  const scaleY = camera.coordinateSpace === 'normalized' ? sceneHeight : 1;
+  return constrainCameraFrame({
+    x: camera.viewport.x * scaleX,
+    y: camera.viewport.y * scaleY,
+    width: camera.viewport.width * scaleX,
+    height: camera.viewport.height * scaleY,
+  }, sceneWidth, sceneHeight);
+}
+
+export function toCameraViewport(
+  viewport: CameraFrameViewport,
+  coordinateSpace: 'scene' | 'normalized',
+  sceneWidth: number,
+  sceneHeight: number,
+): CameraFrameViewport {
+  if (coordinateSpace === 'scene') return viewport;
+  return {
+    x: viewport.x / sceneWidth,
+    y: viewport.y / sceneHeight,
+    width: viewport.width / sceneWidth,
+    height: viewport.height / sceneHeight,
+  };
+}
+
+export function constrainCameraFrame(
+  viewport: CameraFrameViewport,
+  sceneWidth: number,
+  sceneHeight: number,
+): CameraFrameViewport {
+  const width = Math.min(Math.max(viewport.width, MIN_CAMERA_SIZE), sceneWidth);
+  const height = Math.min(Math.max(viewport.height, MIN_CAMERA_SIZE), sceneHeight);
+  return {
+    x: Math.min(Math.max(viewport.x, 0), sceneWidth - width),
+    y: Math.min(Math.max(viewport.y, 0), sceneHeight - height),
+    width,
+    height,
+  };
+}
+
+export function focusCameraFrame(
+  bounds: CameraFrameViewport,
+  sceneWidth: number,
+  sceneHeight: number,
+  padding = Math.max(24, Math.max(bounds.width, bounds.height) * 0.08),
+): CameraFrameViewport {
+  const padded = {
+    x: bounds.x - padding,
+    y: bounds.y - padding,
+    width: bounds.width + padding * 2,
+    height: bounds.height + padding * 2,
+  };
+  const sceneAspect = sceneWidth / sceneHeight;
+  const paddedAspect = padded.width / padded.height;
+  const centerX = padded.x + padded.width / 2;
+  const centerY = padded.y + padded.height / 2;
+  const viewport = paddedAspect < sceneAspect
+    ? { x: centerX - (padded.height * sceneAspect) / 2, y: padded.y, width: padded.height * sceneAspect, height: padded.height }
+    : { x: padded.x, y: centerY - padded.width / sceneAspect / 2, width: padded.width, height: padded.width / sceneAspect };
+  return constrainCameraFrame(viewport, sceneWidth, sceneHeight);
+}
+
+function moveCameraFrame(
+  viewport: CameraFrameViewport,
+  dx: number,
+  dy: number,
+  sceneWidth: number,
+  sceneHeight: number,
+): CameraFrameViewport {
+  return constrainCameraFrame({ ...viewport, x: viewport.x + dx, y: viewport.y + dy }, sceneWidth, sceneHeight);
+}
+
+export function resizeCameraFrame(
+  viewport: CameraFrameViewport,
+  handle: string,
+  dx: number,
+  dy: number,
+  sceneWidth: number,
+  sceneHeight: number,
+  aspectLocked: boolean,
+): CameraFrameViewport {
+  if (!aspectLocked) {
+    const right = viewport.x + viewport.width;
+    const bottom = viewport.y + viewport.height;
+    const left = handle.includes('w')
+      ? Math.min(Math.max(viewport.x + dx, 0), right - MIN_CAMERA_SIZE)
+      : viewport.x;
+    const nextRight = handle.includes('e')
+      ? Math.max(Math.min(right + dx, sceneWidth), left + MIN_CAMERA_SIZE)
+      : right;
+    const top = handle.includes('n')
+      ? Math.min(Math.max(viewport.y + dy, 0), bottom - MIN_CAMERA_SIZE)
+      : viewport.y;
+    const nextBottom = handle.includes('s')
+      ? Math.max(Math.min(bottom + dy, sceneHeight), top + MIN_CAMERA_SIZE)
+      : bottom;
+    return { x: left, y: top, width: nextRight - left, height: nextBottom - top };
+  }
+
+  const aspect = sceneWidth / sceneHeight;
+  const horizontalDelta = handle.includes('e') ? dx : handle.includes('w') ? -dx : undefined;
+  const verticalDelta = handle.includes('s') ? dy * aspect : handle.includes('n') ? -dy * aspect : undefined;
+  const widthDelta = horizontalDelta === undefined
+    ? verticalDelta ?? 0
+    : verticalDelta === undefined || Math.abs(horizontalDelta) >= Math.abs(verticalDelta)
+      ? horizontalDelta
+      : verticalDelta;
+  const horizontalLimit = handle.includes('w')
+    ? viewport.x + viewport.width
+    : handle.includes('e')
+      ? sceneWidth - viewport.x
+      : Math.min(viewport.x + viewport.width / 2, sceneWidth - viewport.x - viewport.width / 2) * 2;
+  const verticalLimit = handle.includes('n')
+    ? viewport.y + viewport.height
+    : handle.includes('s')
+      ? sceneHeight - viewport.y
+      : Math.min(viewport.y + viewport.height / 2, sceneHeight - viewport.y - viewport.height / 2) * 2;
+  const width = Math.min(
+    Math.max(viewport.width + widthDelta, MIN_CAMERA_SIZE),
+    sceneWidth,
+    horizontalLimit,
+    verticalLimit * aspect,
+  );
+  const height = width / aspect;
+  const x = handle.includes('w')
+    ? viewport.x + viewport.width - width
+    : handle.includes('e')
+      ? viewport.x
+      : viewport.x + (viewport.width - width) / 2;
+  const y = handle.includes('n')
+    ? viewport.y + viewport.height - height
+    : handle.includes('s')
+      ? viewport.y
+      : viewport.y + (viewport.height - height) / 2;
+  return { x, y, width, height };
+}
+
+function drawCameraFrame(
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+  sceneWidth: number,
+  sceneHeight: number,
+  aspectLocked: boolean,
+): CameraFrameViewport {
+  if (!aspectLocked) {
+    return constrainCameraFrame({
+      x: Math.min(start.x, end.x),
+      y: Math.min(start.y, end.y),
+      width: Math.abs(end.x - start.x),
+      height: Math.abs(end.y - start.y),
+    }, sceneWidth, sceneHeight);
+  }
+  const aspect = sceneWidth / sceneHeight;
+  const directionX = end.x >= start.x ? 1 : -1;
+  const directionY = end.y >= start.y ? 1 : -1;
+  const widthFromX = Math.abs(end.x - start.x);
+  const widthFromY = Math.abs(end.y - start.y) * aspect;
+  const width = Math.max(widthFromX, widthFromY);
+  const height = width / aspect;
+  return constrainCameraFrame({
+    x: directionX > 0 ? start.x : start.x - width,
+    y: directionY > 0 ? start.y : start.y - height,
+    width,
+    height,
+  }, sceneWidth, sceneHeight);
+}
+
+function toScenePoint(
+  event: React.PointerEvent<SVGElement> | RafDragPoint,
+  svg: SVGSVGElement,
+  sceneWidth: number,
+  sceneHeight: number,
+): { x: number; y: number } {
+  const rect = svg.getBoundingClientRect();
+  return {
+    x: ((event.clientX - rect.left) / rect.width) * sceneWidth,
+    y: ((event.clientY - rect.top) / rect.height) * sceneHeight,
+  };
+}
+
+function sameViewport(left: CameraFrameViewport, right: CameraFrameViewport): boolean {
+  return left.x === right.x && left.y === right.y && left.width === right.width && left.height === right.height;
+}
+
+export function CameraFramingOverlay({
+  viewport,
+  sceneWidth,
+  sceneHeight,
+  aspectLocked,
+  drawing,
+  onViewportChange,
+  onViewportCommit,
+  onDrawingComplete,
+}: CameraFramingOverlayProps) {
+  const latestViewportRef = useRef(viewport);
+  latestViewportRef.current = viewport;
+
+  const beginDrag = useCallback((event: React.PointerEvent<SVGElement>, mode: 'move' | string) => {
+    if (event.button !== 0) return;
+    const svg = event.currentTarget.ownerSVGElement;
+    if (!svg) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const start = toScenePoint(event, svg, sceneWidth, sceneHeight);
+    const initialViewport = viewport;
+    let changed = false;
+
+    startRafDrag({
+      event,
+      moveThreshold: 0,
+      onFrame: point => {
+        const current = toScenePoint(point, svg, sceneWidth, sceneHeight);
+        const next = mode === 'move'
+          ? moveCameraFrame(initialViewport, current.x - start.x, current.y - start.y, sceneWidth, sceneHeight)
+          : resizeCameraFrame(initialViewport, mode, current.x - start.x, current.y - start.y, sceneWidth, sceneHeight, aspectLocked);
+        if (!sameViewport(next, latestViewportRef.current)) {
+          latestViewportRef.current = next;
+          onViewportChange(next);
+          changed = true;
+        }
+      },
+      onCommit: () => {
+        if (changed) onViewportCommit(latestViewportRef.current);
+      },
+    });
+  }, [aspectLocked, onViewportChange, onViewportCommit, sceneHeight, sceneWidth, viewport]);
+
+  const beginDraw = useCallback((event: React.PointerEvent<SVGRectElement>) => {
+    if (event.button !== 0) return;
+    const svg = event.currentTarget.ownerSVGElement;
+    if (!svg) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const start = toScenePoint(event, svg, sceneWidth, sceneHeight);
+    let changed = false;
+
+    startRafDrag({
+      event,
+      moveThreshold: 0,
+      onFrame: point => {
+        const next = drawCameraFrame(start, toScenePoint(point, svg, sceneWidth, sceneHeight), sceneWidth, sceneHeight, aspectLocked);
+        if (!sameViewport(next, latestViewportRef.current)) {
+          latestViewportRef.current = next;
+          onViewportChange(next);
+          changed = true;
+        }
+      },
+      onCommit: () => {
+        if (changed) onViewportCommit(latestViewportRef.current);
+        onDrawingComplete();
+      },
+      onCancel: onDrawingComplete,
+    });
+  }, [aspectLocked, onDrawingComplete, onViewportChange, onViewportCommit, sceneHeight, sceneWidth]);
+
+  const handles = [
+    { id: 'nw', x: viewport.x, y: viewport.y, cursor: 'nw-resize' },
+    { id: 'n', x: viewport.x + viewport.width / 2, y: viewport.y, cursor: 'n-resize' },
+    { id: 'ne', x: viewport.x + viewport.width, y: viewport.y, cursor: 'ne-resize' },
+    { id: 'e', x: viewport.x + viewport.width, y: viewport.y + viewport.height / 2, cursor: 'e-resize' },
+    { id: 'se', x: viewport.x + viewport.width, y: viewport.y + viewport.height, cursor: 'se-resize' },
+    { id: 's', x: viewport.x + viewport.width / 2, y: viewport.y + viewport.height, cursor: 's-resize' },
+    { id: 'sw', x: viewport.x, y: viewport.y + viewport.height, cursor: 'sw-resize' },
+    { id: 'w', x: viewport.x, y: viewport.y + viewport.height / 2, cursor: 'w-resize' },
+  ];
+
+  return (
+    <g className="elucim-editor-camera-frame" aria-label="Camera framing rectangle">
+      <rect
+        x={0}
+        y={0}
+        width={sceneWidth}
+        height={sceneHeight}
+        fill="transparent"
+        style={{ pointerEvents: 'all' }}
+        onPointerDown={event => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+      />
+      <rect x={0} y={0} width={sceneWidth} height={viewport.y} fill={v('--elucim-editor-overlay')} pointerEvents="none" />
+      <rect x={0} y={viewport.y} width={viewport.x} height={viewport.height} fill={v('--elucim-editor-overlay')} pointerEvents="none" />
+      <rect x={viewport.x + viewport.width} y={viewport.y} width={sceneWidth - viewport.x - viewport.width} height={viewport.height} fill={v('--elucim-editor-overlay')} pointerEvents="none" />
+      <rect x={0} y={viewport.y + viewport.height} width={sceneWidth} height={sceneHeight - viewport.y - viewport.height} fill={v('--elucim-editor-overlay')} pointerEvents="none" />
+      <rect
+        x={viewport.x}
+        y={viewport.y}
+        width={viewport.width}
+        height={viewport.height}
+        fill="none"
+        stroke={v('--elucim-editor-accent')}
+        strokeWidth={2}
+        strokeDasharray="6 3"
+        style={{ pointerEvents: 'stroke', cursor: 'move' }}
+        onPointerDown={event => beginDrag(event, 'move')}
+      />
+      <circle
+        cx={viewport.x + viewport.width / 2}
+        cy={viewport.y + viewport.height / 2}
+        r={HANDLE_SIZE / 2}
+        fill={v('--elucim-editor-accent')}
+        stroke={v('--elucim-editor-handle-fill')}
+        strokeWidth={1.5}
+        data-testid="camera-frame-move-handle"
+        style={{ pointerEvents: 'all', cursor: 'move' }}
+        onPointerDown={event => beginDrag(event, 'move')}
+      />
+      {handles.map(handle => (
+        <rect
+          key={handle.id}
+          x={handle.x - HANDLE_SIZE / 2}
+          y={handle.y - HANDLE_SIZE / 2}
+          width={HANDLE_SIZE}
+          height={HANDLE_SIZE}
+          rx={1}
+          fill={v('--elucim-editor-handle-fill')}
+          stroke={v('--elucim-editor-accent')}
+          strokeWidth={1.5}
+          data-testid={`camera-frame-handle-${handle.id}`}
+          style={{ pointerEvents: 'all', cursor: handle.cursor }}
+          onPointerDown={event => beginDrag(event, handle.id)}
+        />
+      ))}
+      {drawing && (
+        <rect
+          x={0}
+          y={0}
+          width={sceneWidth}
+          height={sceneHeight}
+          fill="transparent"
+          data-testid="camera-frame-draw-surface"
+          style={{ pointerEvents: 'all', cursor: 'crosshair' }}
+          onPointerDown={beginDraw}
+        />
+      )}
+    </g>
+  );
+}

--- a/packages/editor/src/canvas/EditorCanvasPanel.tsx
+++ b/packages/editor/src/canvas/EditorCanvasPanel.tsx
@@ -1,19 +1,21 @@
 import type { ElucimTheme } from '@elucim/core';
-import type { RenderableDocument } from '@elucim/dsl';
+import type { CameraNode, RenderableDocument } from '@elucim/dsl';
 import { ElucimCanvas } from './ElucimCanvas';
 import type { EditorStateMachinePreviewMode } from './editorPreviewController';
 
 export interface EditorCanvasPanelProps {
   previewDocument?: RenderableDocument;
+  previewCamera?: CameraNode;
   previewMode: EditorStateMachinePreviewMode;
   editorColorScheme?: string;
   contentTheme?: ElucimTheme;
 }
 
-export function EditorCanvasPanel({ previewDocument, previewMode, editorColorScheme, contentTheme }: EditorCanvasPanelProps) {
+export function EditorCanvasPanel({ previewDocument, previewCamera, previewMode, editorColorScheme, contentTheme }: EditorCanvasPanelProps) {
   return (
     <ElucimCanvas
       previewDocument={previewDocument}
+      previewCamera={previewCamera}
       previewMode={previewMode}
       editorColorScheme={editorColorScheme}
       contentTheme={contentTheme}

--- a/packages/editor/src/canvas/ElucimCanvas.tsx
+++ b/packages/editor/src/canvas/ElucimCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useCallback, useState, useEffect, useMemo } from 'react';
 import { Scene } from '@elucim/core';
-import { renderElement } from '@elucim/dsl';
-import type { RenderableDocument as ElucimDocument, ElementNode } from '@elucim/dsl';
+import { resolveCameraViewport, SceneCameraViewport, renderElement } from '@elucim/dsl';
+import type { CameraNode, RenderableDocument as ElucimDocument, ElementNode } from '@elucim/dsl';
 import { resolveColor, DARK_THEME, LIGHT_THEME, normalizeTheme, themeToVars, type ElucimTheme } from '@elucim/core';
 import { useEditorState } from '../state/EditorProvider';
 import { getElementId } from '../state/types';
@@ -21,12 +21,22 @@ import { exportEditorDocumentToJson, importFromJson } from '../utils/io';
 import { ContextMenu } from './ContextMenu';
 import type { ContextMenuItem } from './ContextMenu';
 import { buildElementContextMenuItems } from './contextMenuItems';
+import {
+  CameraFramingOverlay,
+  constrainCameraFrame,
+  focusCameraFrame,
+  getSceneCameraViewport,
+  type CameraFrameViewport,
+} from './CameraFramingOverlay';
+import { upsertTimelineCameraKeyframe } from '../timeline/cameraKeyframes';
 
 export interface ElucimCanvasProps {
   className?: string;
   style?: React.CSSProperties;
   /** Optional render-only document, used for timeline/state preview without mutating editor state. */
   previewDocument?: ElucimDocument;
+  /** Evaluated camera for a render-only timeline/state preview. */
+  previewCamera?: CameraNode;
   /** Optional preview mode chrome and event routing for render-only document previews. */
   previewMode?: {
     active: boolean;
@@ -62,6 +72,23 @@ function resolveSelectionBounds(
   const bounds = getElementBounds(loc.element);
   if (!bounds) return null;
   return applyAncestorTransforms(root, loc.parentPath, bounds);
+}
+
+function resolveLogicalSelectionBounds(root: ElucimDocument['root'], id: string): BoundingBox | null {
+  const loc = findElementById(root, id);
+  if (!loc) return null;
+  const bounds = getElementBounds(loc.element);
+  return bounds ? applyAncestorTransforms(root, loc.parentPath, bounds) : null;
+}
+
+function mapBoundsThroughCamera(bounds: BoundingBox, camera: CameraNode, width: number, height: number): BoundingBox {
+  const transform = resolveCameraViewport(camera, width, height);
+  return {
+    x: transform.offsetX + (bounds.x - transform.viewport.x) * transform.scale,
+    y: transform.offsetY + (bounds.y - transform.viewport.y) * transform.scale,
+    width: bounds.width * transform.scale,
+    height: bounds.height * transform.scale,
+  };
 }
 
 function measureNestedElementBounds(
@@ -262,9 +289,18 @@ function isDarkBackground(bg: string): boolean {
 /**
  * Full-bleed editor canvas with viewport pan/zoom, dot grid, minimap, and zoom controls.
  */
-export function ElucimCanvas({ className, style, previewDocument, previewMode, editorColorScheme, contentTheme }: ElucimCanvasProps) {
+export function ElucimCanvas({ className, style, previewDocument, previewCamera, previewMode, editorColorScheme, contentTheme }: ElucimCanvasProps) {
   const { state, dispatch } = useEditorState();
-  const { document: editorDocument, selectedIds, currentFrame, viewport, isPanning } = state;
+  const {
+    document: editorDocument,
+    selectedIds,
+    currentFrame,
+    viewport,
+    isPanning,
+    isCameraFraming,
+    cameraFramingTimelineId,
+    cameraFramingFrame,
+  } = state;
   const document = previewDocument ?? editorDocument;
   const root = document.root;
   const overlaySvgRef = useRef<SVGSVGElement>(null);
@@ -279,6 +315,10 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
   } | null>(null);
   const inlineEditRef = useRef<HTMLTextAreaElement>(null);
   const [isCanvasHovered, setIsCanvasHovered] = useState(false);
+  const [cameraDraft, setCameraDraft] = useState<CameraFrameViewport | null>(null);
+  const [cameraAspectLocked, setCameraAspectLocked] = useState(true);
+  const [isDrawingCameraFrame, setIsDrawingCameraFrame] = useState(false);
+  const cameraFramingSessionRef = useRef<string>();
   const previewModeActive = Boolean(previewMode?.active);
 
   // Resolve scene dimensions
@@ -288,6 +328,21 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
   const durationInFrames = ('durationInFrames' in root ? root.durationInFrames : undefined) ?? 120;
   const rawBackground = ('background' in root ? root.background : undefined) as string | undefined;
   const background = resolveColor(rawBackground) ?? '#0f172a';
+  const camera = previewDocument ? previewCamera : undefined;
+  const renderedCamera = isCameraFraming ? undefined : camera;
+
+  useEffect(() => {
+    if (!isCameraFraming) {
+      cameraFramingSessionRef.current = undefined;
+      return;
+    }
+    const session = `${cameraFramingTimelineId ?? ''}:${cameraFramingFrame ?? currentFrame}`;
+    if (cameraFramingSessionRef.current === session) return;
+    cameraFramingSessionRef.current = session;
+    setCameraDraft(getSceneCameraViewport(camera, width, height));
+    setCameraAspectLocked(true);
+    setIsDrawingCameraFrame(false);
+  }, [camera, cameraFramingFrame, cameraFramingTimelineId, currentFrame, height, isCameraFraming, width]);
 
   // Set --elucim-* content theme CSS vars so $token references in elements resolve correctly.
   // When editorColorScheme is explicitly light/dark, use it directly — this avoids
@@ -356,6 +411,7 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
     sceneWidth: width,
     sceneHeight: height,
     selectedIds,
+    camera: renderedCamera,
   });
 
   // Keyboard shortcuts
@@ -376,12 +432,20 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
     zoom: state.viewport.zoom,
     isPlaying: state.isPlaying,
     isCanvasHovered,
+    isCameraFraming,
     getDocumentJson,
     importDocument: handleImport,
   });
 
   // DOM-measured bounds — pixel-perfect for every element type
   const measuredBounds = useMeasuredBounds(sceneSvgRef, elementIds, children);
+  const interactionBounds = useMemo(() => {
+    if (!renderedCamera) return measuredBounds;
+    return new Map(elementIds.flatMap(id => {
+      const bounds = resolveLogicalSelectionBounds(root, id);
+      return bounds ? [[id, bounds] as const] : [];
+    }));
+  }, [elementIds, measuredBounds, renderedCamera, root]);
 
   // Marquee (lasso) selection — drag on empty canvas to select
   const {
@@ -395,13 +459,18 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
     containerRef,
     isPanning,
     activeTool: state.activeTool,
-    boundsMap: measuredBounds,
+    boundsMap: interactionBounds,
+    sceneWidth: width,
+    sceneHeight: height,
+    camera: renderedCamera,
   });
 
   // Collect selected element bounds for the overlay
   const selectedBounds = selectedIds
     .map(id => {
-      const bounds = resolveSelectionBounds(root, measuredBounds, sceneSvgRef.current, id);
+      const bounds = renderedCamera
+        ? resolveLogicalSelectionBounds(root, id)
+        : resolveSelectionBounds(root, measuredBounds, sceneSvgRef.current, id);
       return bounds ? { id, bounds } : null;
     })
     .filter((b): b is NonNullable<typeof b> => b !== null);
@@ -416,12 +485,59 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
       : null;
     if (!field) return false;
 
-    const bounds = resolveSelectionBounds(root, measuredBounds, sceneSvgRef.current, id);
+    const logicalBounds = renderedCamera
+      ? resolveLogicalSelectionBounds(root, id)
+      : resolveSelectionBounds(root, measuredBounds, sceneSvgRef.current, id);
+    const bounds = logicalBounds && renderedCamera
+      ? mapBoundsThroughCamera(logicalBounds, renderedCamera, width, height)
+      : logicalBounds;
     if (!bounds) return false;
     setInlineEdit({ id, field, value: element[field] ?? '', bounds });
     dispatch({ type: 'SELECT', ids: [id] });
     return true;
-  }, [dispatch, measuredBounds, root]);
+  }, [dispatch, height, measuredBounds, renderedCamera, root, width]);
+
+  const commitCameraFrame = useCallback((nextViewport: CameraFrameViewport) => {
+    const canonicalDocument = state.canonicalDocument;
+    const timeline = cameraFramingTimelineId
+      ? canonicalDocument?.timelines?.[cameraFramingTimelineId]
+      : undefined;
+    if (!canonicalDocument || !timeline) return;
+    const nextTimeline = upsertTimelineCameraKeyframe(
+      timeline,
+      camera,
+      cameraFramingFrame ?? currentFrame,
+      nextViewport,
+      width,
+      height,
+    );
+    dispatch({ type: 'UPDATE_TIMELINE_CAMERA', timelineId: timeline.id, camera: nextTimeline.camera! });
+  }, [camera, cameraFramingFrame, cameraFramingTimelineId, currentFrame, dispatch, height, state.canonicalDocument, width]);
+
+  const completeCameraFraming = useCallback(() => {
+    if (cameraDraft) commitCameraFrame(cameraDraft);
+    dispatch({ type: 'SET_CAMERA_FRAMING', framing: false });
+  }, [cameraDraft, commitCameraFrame, dispatch]);
+
+  const cancelCameraFraming = useCallback(() => {
+    dispatch({ type: 'SET_CAMERA_FRAMING', framing: false });
+  }, [dispatch]);
+
+  const focusSelectedCameraFrame = useCallback(() => {
+    if (selectedIds.length !== 1 || selectedIds[0] === '__canvas__') return;
+    const bounds = resolveLogicalSelectionBounds(root, selectedIds[0]);
+    if (bounds) setCameraDraft(focusCameraFrame(bounds, width, height));
+  }, [height, root, selectedIds, width]);
+
+  const updateCameraDraftField = useCallback((field: keyof CameraFrameViewport, value: string) => {
+    if (value === '') return;
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) return;
+    setCameraDraft(current => current
+      ? constrainCameraFrame({ ...current, [field]: numericValue }, width, height)
+      : current,
+    );
+  }, [height, width]);
 
   const commitInlineEdit = useCallback(() => {
     if (!inlineEdit) return;
@@ -455,7 +571,7 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
   // Build hit-test targets for all elements
   const hitTargets = elementIds
     .map(id => {
-      const bounds = measuredBounds.get(id);
+      const bounds = interactionBounds.get(id);
       return bounds ? { id, bounds } : null;
     })
     .filter((t): t is NonNullable<typeof t> => t !== null);
@@ -503,17 +619,17 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
   }, [beginInlineEdit]);
 
   const handleContainerPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!shouldPreservePointerFocus(e.target)) {
-      e.currentTarget.focus({ preventScroll: true });
-    }
-    if (previewModeActive && !shouldPreservePointerFocus(e.target) && previewMode?.onClick?.()) {
+    if (shouldPreservePointerFocus(e.target)) return;
+    if (isCameraFraming) return;
+    e.currentTarget.focus({ preventScroll: true });
+    if (previewModeActive && previewMode?.onClick?.()) {
       e.preventDefault();
       e.stopPropagation();
       return;
     }
     handlePanStart(e);
     handleMarqueeStart(e);
-  }, [handleMarqueeStart, handlePanStart, previewMode, previewModeActive]);
+  }, [handleMarqueeStart, handlePanStart, isCameraFraming, previewMode, previewModeActive]);
 
   const handleContainerKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!previewModeActive || shouldPreservePointerFocus(e.target)) return;
@@ -628,11 +744,13 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
           background={background}
           frame={currentFrame}
         >
-          {children.map((child, i) => (
-            <g key={elementIds[i]} data-measure-id={elementIds[i]}>
-              {renderElement(child, i)}
-            </g>
-          ))}
+          <SceneCameraViewport camera={renderedCamera} width={width} height={height}>
+            {children.map((child, i) => (
+              <g key={elementIds[i]} data-measure-id={elementIds[i]}>
+                {renderElement(child, i)}
+              </g>
+            ))}
+          </SceneCameraViewport>
         </Scene>
 
         {/* Overlay layer */}
@@ -653,42 +771,103 @@ export function ElucimCanvas({ className, style, previewDocument, previewMode, e
           onPointerUp={handlePointerUp}
           onDoubleClick={handleOverlayDoubleClick}
         >
-          {hitTargets.map(({ id, bounds }) => {
-            const { rotation, rotationCenter } = bounds;
-            const transform = rotation && rotationCenter
-              ? `rotate(${rotation}, ${rotationCenter[0]}, ${rotationCenter[1]})`
-              : undefined;
-            return (
+          <SceneCameraViewport camera={renderedCamera} width={width} height={height}>
+            {!isCameraFraming && hitTargets.map(({ id, bounds }) => {
+              const { rotation, rotationCenter } = bounds;
+              const transform = rotation && rotationCenter
+                ? `rotate(${rotation}, ${rotationCenter[0]}, ${rotationCenter[1]})`
+                : undefined;
+              return (
+                <rect
+                  key={`hit-${id}`}
+                  data-editor-id={id}
+                  x={bounds.x}
+                  y={bounds.y}
+                  width={bounds.width}
+                  height={bounds.height}
+                  fill="transparent"
+                  transform={transform}
+                  style={{ pointerEvents: 'all', cursor: isPanning ? 'grab' : 'default' }}
+                />
+              );
+            })}
+            {!isCameraFraming && <SelectionOverlay selections={selectedBounds} />}
+            {/* Marquee selection rectangle */}
+            {!isCameraFraming && marquee && (
               <rect
-                key={`hit-${id}`}
-                data-editor-id={id}
-                x={bounds.x}
-                y={bounds.y}
-                width={bounds.width}
-                height={bounds.height}
-                fill="transparent"
-                transform={transform}
-                style={{ pointerEvents: 'all', cursor: isPanning ? 'grab' : 'default' }}
+                x={marquee.x}
+                y={marquee.y}
+                width={marquee.width}
+                height={marquee.height}
+                fill={v('--elucim-editor-accent')}
+                fillOpacity={0.1}
+                stroke={v('--elucim-editor-accent')}
+                strokeWidth={1}
+                strokeDasharray="6 3"
+                style={{ pointerEvents: 'none' }}
               />
-            );
-          })}
-          <SelectionOverlay selections={selectedBounds} />
-          {/* Marquee selection rectangle */}
-          {marquee && (
-            <rect
-              x={marquee.x}
-              y={marquee.y}
-              width={marquee.width}
-              height={marquee.height}
-              fill={v('--elucim-editor-accent')}
-              fillOpacity={0.1}
-              stroke={v('--elucim-editor-accent')}
-              strokeWidth={1}
-              strokeDasharray="6 3"
-              style={{ pointerEvents: 'none' }}
+            )}
+          </SceneCameraViewport>
+          {isCameraFraming && cameraDraft && (
+            <CameraFramingOverlay
+              viewport={cameraDraft}
+              sceneWidth={width}
+              sceneHeight={height}
+              aspectLocked={cameraAspectLocked}
+              drawing={isDrawingCameraFrame}
+              onViewportChange={setCameraDraft}
+              onViewportCommit={setCameraDraft}
+              onDrawingComplete={() => setIsDrawingCameraFrame(false)}
             />
           )}
         </svg>
+        {isCameraFraming && cameraDraft && (
+          <div
+            aria-label="Camera framing controls"
+            style={{
+              position: 'absolute',
+              top: 12,
+              left: 12,
+              zIndex: 6,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: 6,
+              border: `1px solid ${v('--elucim-editor-accent')}`,
+              borderRadius: 6,
+              background: v('--elucim-editor-panel'),
+              boxShadow: v('--elucim-editor-shadow-dropdown'),
+            }}
+          >
+            <strong style={{ fontSize: 11, color: v('--elucim-editor-fg') }}>Camera frame</strong>
+          {(['x', 'y', 'width', 'height'] as const).map(field => (
+            <label key={field} style={{ display: 'flex', alignItems: 'center', gap: 3, fontSize: 10 }}>
+              {field === 'width' ? 'W' : field === 'height' ? 'H' : field.toUpperCase()}
+              <input
+                aria-label={`Camera frame ${field}`}
+                type="number"
+                min={field === 'width' || field === 'height' ? 1 : 0}
+                step={1}
+                value={cameraDraft[field]}
+                onChange={event => updateCameraDraftField(field, event.currentTarget.value)}
+                style={{ width: 54 }}
+              />
+            </label>
+          ))}
+          <button type="button" aria-pressed={cameraAspectLocked} onClick={() => setCameraAspectLocked(locked => !locked)}>
+              {cameraAspectLocked ? 'Lock aspect' : 'Free aspect'}
+            </button>
+            <button type="button" aria-pressed={isDrawingCameraFrame} onClick={() => setIsDrawingCameraFrame(drawing => !drawing)}>
+              {isDrawingCameraFrame ? 'Cancel draw' : 'Draw frame'}
+            </button>
+            <button type="button" disabled={selectedIds.length !== 1 || selectedIds[0] === '__canvas__'} onClick={focusSelectedCameraFrame}>
+              Focus selection
+            </button>
+            <button type="button" onClick={() => setCameraDraft({ x: 0, y: 0, width, height })}>Reset</button>
+            <button type="button" onClick={completeCameraFraming}>Done</button>
+            <button type="button" onClick={cancelCameraFraming}>Cancel</button>
+          </div>
+        )}
         {inlineEdit && (
           <textarea
             ref={inlineEditRef}

--- a/packages/editor/src/canvas/editorPreviewController.ts
+++ b/packages/editor/src/canvas/editorPreviewController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
-import type { ElucimDocument, ElucimTimelineFrameSelection, RenderableDocument } from '@elucim/dsl';
-import { resolvePreviewDocument } from '../document/documentLifecycle';
+import type { CameraNode, ElucimDocument, ElucimTimelineFrameSelection, RenderableDocument } from '@elucim/dsl';
+import { resolvePreviewCamera, resolvePreviewDocument } from '../document/documentLifecycle';
 
 export interface EditorStateMachinePreviewMode {
   active: boolean;
@@ -21,6 +21,7 @@ export interface EditorTimelinePreviewCallbacks {
 
 export interface EditorPreviewController {
   previewDocument: RenderableDocument | undefined;
+  previewCamera: CameraNode | undefined;
   stateMachinePreviewMode: EditorStateMachinePreviewMode;
   timelinePreviewCallbacks: EditorTimelinePreviewCallbacks;
 }
@@ -46,6 +47,10 @@ export function useEditorPreviewController(liveDocument: ElucimDocument | undefi
 
   const previewDocument = useMemo(
     () => resolvePreviewDocument(liveDocument, previewTimelineFrames),
+    [liveDocument, previewTimelineFrames],
+  );
+  const previewCamera = useMemo(
+    () => resolvePreviewCamera(liveDocument, previewTimelineFrames),
     [liveDocument, previewTimelineFrames],
   );
 
@@ -76,5 +81,5 @@ export function useEditorPreviewController(liveDocument: ElucimDocument | undefi
     setPreviewExitHandler,
   ]);
 
-  return { previewDocument, stateMachinePreviewMode, timelinePreviewCallbacks };
+  return { previewDocument, previewCamera, stateMachinePreviewMode, timelinePreviewCallbacks };
 }

--- a/packages/editor/src/canvas/useDrag.ts
+++ b/packages/editor/src/canvas/useDrag.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react';
 import type { Dispatch } from 'react';
+import { resolveCameraViewport, type CameraNode } from '@elucim/dsl';
 import type { EditorAction } from '../state/types';
 import type { BoundingBox } from '../utils/bounds';
 import { startRafDrag, type RafDragPoint } from '../interactions/rafDrag';
@@ -21,6 +22,7 @@ interface UseDragOptions {
   sceneWidth: number;
   sceneHeight: number;
   selectedIds: string[];
+  camera?: CameraNode;
 }
 
 /** Convert a mouse event to SVG coordinates */
@@ -29,18 +31,24 @@ function toSvgCoords(
   svgEl: SVGSVGElement,
   sceneWidth: number,
   sceneHeight: number,
+  camera?: CameraNode,
 ): { x: number; y: number } {
   const rect = svgEl.getBoundingClientRect();
   const x = ((e.clientX - rect.left) / rect.width) * sceneWidth;
   const y = ((e.clientY - rect.top) / rect.height) * sceneHeight;
-  return { x, y };
+  if (!camera) return { x, y };
+  const transform = resolveCameraViewport(camera, sceneWidth, sceneHeight);
+  return {
+    x: (x - transform.offsetX) / transform.scale + transform.viewport.x,
+    y: (y - transform.offsetY) / transform.scale + transform.viewport.y,
+  };
 }
 
 /**
  * Hook providing drag-to-move, resize, and rotation interactions.
  * Returns pointer event handlers to attach to the overlay SVG.
  */
-export function useDrag({ dispatch, svgRef, sceneWidth, sceneHeight, selectedIds }: UseDragOptions) {
+export function useDrag({ dispatch, svgRef, sceneWidth, sceneHeight, selectedIds, camera }: UseDragOptions) {
   const dragRef = useRef<DragState | null>(null);
   const accDx = useRef(0);
   const accDy = useRef(0);
@@ -56,7 +64,7 @@ export function useDrag({ dispatch, svgRef, sceneWidth, sceneHeight, selectedIds
     const svg = svgRef.current;
     if (!svg) return;
 
-    const coords = toSvgCoords(e, svg, sceneWidth, sceneHeight);
+    const coords = toSvgCoords(e, svg, sceneWidth, sceneHeight, camera);
 
     // Check for resize handle
     const handleAttr = target.getAttribute('data-handle');
@@ -111,7 +119,7 @@ export function useDrag({ dispatch, svgRef, sceneWidth, sceneHeight, selectedIds
       const currentSvg = svgRef.current;
       if (!drag || !currentSvg) return;
 
-      const currentCoords = toSvgCoords(point, currentSvg, sceneWidth, sceneHeight);
+      const currentCoords = toSvgCoords(point, currentSvg, sceneWidth, sceneHeight, camera);
       const dx = currentCoords.x - drag.startX - accDx.current;
       const dy = currentCoords.y - drag.startY - accDy.current;
 
@@ -178,7 +186,7 @@ export function useDrag({ dispatch, svgRef, sceneWidth, sceneHeight, selectedIds
         activeDragType.current = null;
       },
     });
-  }, [dispatch, svgRef, sceneWidth, sceneHeight, selectedIds]);
+  }, [camera, dispatch, svgRef, sceneWidth, sceneHeight, selectedIds]);
 
   const handlePointerMove = useCallback((_e: React.PointerEvent<SVGSVGElement>) => {}, []);
 

--- a/packages/editor/src/canvas/useKeyboard.ts
+++ b/packages/editor/src/canvas/useKeyboard.ts
@@ -16,6 +16,8 @@ interface UseKeyboardOptions {
   isPlaying: boolean;
   /** Whether the pointer is over the canvas workspace */
   isCanvasHovered: boolean;
+  /** Whether visual camera framing has exclusive editor input. */
+  isCameraFraming?: boolean;
   /** Callback to get the current document as JSON string */
   getDocumentJson: () => string;
   /** Callback to import a document from JSON string */
@@ -43,11 +45,17 @@ let elementClipboard: string | null = null;
  * - Ctrl+] / Ctrl+[: Bring forward / send backward
  * - Ctrl+Shift+] / Ctrl+Shift+[: Bring to front / send to back
  */
-export function useKeyboardShortcuts({ dispatch, selectedIds, document, zoom, isPlaying, isCanvasHovered, getDocumentJson, importDocument }: UseKeyboardOptions) {
+export function useKeyboardShortcuts({ dispatch, selectedIds, document, zoom, isPlaying, isCanvasHovered, isCameraFraming = false, getDocumentJson, importDocument }: UseKeyboardOptions) {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     // Don't intercept if user is typing in an input
     const tag = (e.target as HTMLElement).tagName;
     if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+    if (isCameraFraming) {
+      e.preventDefault();
+      if (e.key === 'Escape') dispatch({ type: 'SET_CAMERA_FRAMING', framing: false });
+      return;
+    }
 
     const ctrl = e.ctrlKey || e.metaKey;
     const hasSelection = selectedIds.length > 0 && !(selectedIds.length === 1 && selectedIds[0] === CANVAS_ID);
@@ -202,13 +210,14 @@ export function useKeyboardShortcuts({ dispatch, selectedIds, document, zoom, is
         }
         break;
     }
-  }, [dispatch, selectedIds, document, zoom, isPlaying, isCanvasHovered, getDocumentJson, importDocument]);
+  }, [dispatch, selectedIds, document, zoom, isPlaying, isCanvasHovered, isCameraFraming, getDocumentJson, importDocument]);
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    if (isCameraFraming) return;
     if (e.key === ' ') {
       dispatch({ type: 'SET_PANNING', panning: false });
     }
-  }, [dispatch]);
+  }, [dispatch, isCameraFraming]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/packages/editor/src/canvas/useMarquee.ts
+++ b/packages/editor/src/canvas/useMarquee.ts
@@ -5,6 +5,7 @@ import { CANVAS_ID } from '../state/types';
 import type { BoundingBox } from '../utils/bounds';
 import { screenToScene } from './useViewport';
 import { startRafDrag } from '../interactions/rafDrag';
+import { resolveCameraViewport, type CameraNode } from '@elucim/dsl';
 
 export interface MarqueeRect {
   x: number;
@@ -21,6 +22,9 @@ interface UseMarqueeOptions {
   activeTool: string;
   /** Map of element ID → measured bounds */
   boundsMap: Map<string, BoundingBox>;
+  sceneWidth: number;
+  sceneHeight: number;
+  camera?: CameraNode;
 }
 
 /**
@@ -35,6 +39,9 @@ export function useMarquee({
   isPanning,
   activeTool,
   boundsMap,
+  sceneWidth,
+  sceneHeight,
+  camera,
 }: UseMarqueeOptions) {
   const [marquee, setMarquee] = useState<MarqueeRect | null>(null);
   const startRef = useRef<{ sceneX: number; sceneY: number } | null>(null);
@@ -57,7 +64,7 @@ export function useMarquee({
     if (!container) return;
 
     const rect = container.getBoundingClientRect();
-    const scene = screenToScene(e.clientX, e.clientY, rect, viewport);
+    const scene = screenToMarqueeScene(e.clientX, e.clientY, rect, viewport, sceneWidth, sceneHeight, camera);
 
     const start = { sceneX: scene.x, sceneY: scene.y };
     startRef.current = start;
@@ -68,7 +75,7 @@ export function useMarquee({
       event: e,
       onFrame: point => {
         const frameRect = container.getBoundingClientRect();
-        const current = screenToScene(point.clientX, point.clientY, frameRect, viewport);
+        const current = screenToMarqueeScene(point.clientX, point.clientY, frameRect, viewport, sceneWidth, sceneHeight, camera);
         const x = Math.min(start.sceneX, current.x);
         const y = Math.min(start.sceneY, current.y);
         const width = Math.abs(current.x - start.sceneX);
@@ -80,7 +87,7 @@ export function useMarquee({
       onCommit: point => {
         startRef.current = null;
         const commitRect = container.getBoundingClientRect();
-        const current = screenToScene(point.clientX, point.clientY, commitRect, viewport);
+        const current = screenToMarqueeScene(point.clientX, point.clientY, commitRect, viewport, sceneWidth, sceneHeight, camera);
         const x = Math.min(start.sceneX, current.x);
         const y = Math.min(start.sceneY, current.y);
         const w = Math.abs(current.x - start.sceneX);
@@ -125,7 +132,7 @@ export function useMarquee({
         setMarquee(null);
       },
     });
-  }, [dispatch, isPanning, activeTool, viewport, containerRef, boundsMap]);
+  }, [dispatch, isPanning, activeTool, viewport, containerRef, boundsMap, sceneWidth, sceneHeight, camera]);
 
   const handleMarqueeMove = useCallback((_e: React.PointerEvent) => {}, []);
 
@@ -136,6 +143,24 @@ export function useMarquee({
     handleMarqueeStart,
     handleMarqueeMove,
     handleMarqueeEnd,
+  };
+}
+
+export function screenToMarqueeScene(
+  clientX: number,
+  clientY: number,
+  rect: DOMRect,
+  viewport: Viewport,
+  sceneWidth: number,
+  sceneHeight: number,
+  camera?: CameraNode,
+): { x: number; y: number } {
+  const scene = screenToScene(clientX, clientY, rect, viewport);
+  if (!camera) return scene;
+  const transform = resolveCameraViewport(camera, sceneWidth, sceneHeight);
+  return {
+    x: (scene.x - transform.offsetX) / transform.scale + transform.viewport.x,
+    y: (scene.y - transform.offsetY) / transform.scale + transform.viewport.y,
   };
 }
 

--- a/packages/editor/src/document/documentLifecycle.tsx
+++ b/packages/editor/src/document/documentLifecycle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
-import type { ElucimDocument, ElucimTimelineFrameSelection, RenderableDocument } from '@elucim/dsl';
-import { applyTimelineFrames, createRenderableDocument } from '@elucim/dsl';
+import type { CameraNode, ElucimDocument, ElucimTimelineFrameSelection, RenderableDocument } from '@elucim/dsl';
+import { applyTimelineFrames, createRenderableDocument, evaluateTimelineCameraFrames } from '@elucim/dsl';
 import { useEditorState } from '../state/EditorProvider';
 import { createDocumentFromEditorState } from './documentCompatibility';
 
@@ -28,6 +28,15 @@ export function resolvePreviewDocument(
   const renderableFrames = previewTimelineFrames.filter(frame => document.timelines?.[frame.timelineId]);
   if (renderableFrames.length === 0) return undefined;
   return createRenderableDocument(applyTimelineFrames(document, renderableFrames));
+}
+
+export function resolvePreviewCamera(
+  document: ElucimDocument | undefined,
+  previewTimelineFrames: ElucimTimelineFrameSelection[] | undefined,
+): CameraNode | undefined {
+  if (!document || !previewTimelineFrames?.length) return undefined;
+  const renderableFrames = previewTimelineFrames.filter(frame => document.timelines?.[frame.timelineId]);
+  return renderableFrames.length > 0 ? evaluateTimelineCameraFrames(document, renderableFrames) : undefined;
 }
 
 /** Emits canonical document changes from internal editor state. */

--- a/packages/editor/src/inspector/Inspector.tsx
+++ b/packages/editor/src/inspector/Inspector.tsx
@@ -54,6 +54,8 @@ export function Inspector({ className, style, showCanvasDuration = true }: Inspe
   // Canvas inspector
   if (isCanvasSelected) {
     const root = document.root as any;
+    const activeTimelineId = state.activeTimelineId;
+    const activeTimeline = activeTimelineId ? state.canonicalDocument?.timelines?.[activeTimelineId] : undefined;
     return (
       <div
         ref={inspectorRef}
@@ -71,6 +73,36 @@ export function Inspector({ className, style, showCanvasDuration = true }: Inspe
 
         <InspectorSection title="Appearance">
           <ColorField label="Background" value={root.background ?? '#0f172a'} onChange={val => handleCanvasChange('background', val)} />
+        </InspectorSection>
+
+        <InspectorSection title="Camera">
+          {activeTimeline ? (
+            <>
+              <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, lineHeight: 1.4, marginBottom: 8 }}>
+                Camera framing creates or replaces a keyframe in <strong>{activeTimeline.id}</strong> at the current playhead.
+                State-machine states use this timeline camera through their normal active path.
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  dispatch({ type: 'SET_PLAYING', playing: false });
+                  dispatch({
+                    type: 'SET_CAMERA_FRAMING',
+                    framing: true,
+                    timelineId: activeTimeline.id,
+                    frame: state.currentFrame,
+                  });
+                }}
+                style={{ width: '100%', padding: '5px 8px', border: `1px solid ${v('--elucim-editor-accent')}`, borderRadius: 4, background: 'transparent', color: v('--elucim-editor-fg'), cursor: 'pointer', fontSize: 11 }}
+              >
+                Frame timeline camera
+              </button>
+            </>
+          ) : (
+            <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, lineHeight: 1.4 }}>
+              Select or create an animation timeline to author camera keyframes. State-machine camera behavior is defined by the timeline assigned to each state.
+            </div>
+          )}
         </InspectorSection>
 
         <InspectorSection title="Playback">
@@ -371,7 +403,7 @@ function NumberField({ label, value, onChange, step = 1, liveUpdate = true }: {
   }, [value]);
   const commit = (str: string) => {
     const num = parseFloat(str);
-    if (!isNaN(num)) { onChange(num); committedRef.current = num; }
+    if (Number.isFinite(num)) { onChange(num); committedRef.current = num; }
     else setLocalStr(String(value ?? ''));
   };
   return (
@@ -384,7 +416,7 @@ function NumberField({ label, value, onChange, step = 1, liveUpdate = true }: {
         onChange={e => {
           setLocalStr(e.target.value);
           const num = parseFloat(e.target.value);
-          if (liveUpdate && !isNaN(num)) { onChange(num); committedRef.current = num; }
+          if (liveUpdate && Number.isFinite(num)) { onChange(num); committedRef.current = num; }
         }}
         onBlur={() => commit(localStr)}
         onKeyDown={e => { if (e.key === 'Enter') commit(localStr); }}

--- a/packages/editor/src/layout/editorLayoutController.tsx
+++ b/packages/editor/src/layout/editorLayoutController.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import type { ElucimDocument, RenderableDocument } from '@elucim/dsl';
+import type { CameraNode, ElucimDocument, RenderableDocument } from '@elucim/dsl';
 import type { ElucimTheme } from '@elucim/core';
 import type { EditorRootProps } from '../chrome/EditorRoot';
 import type { EditorWorkspaceSurfaceProps } from '../chrome/EditorWorkspaceSurface';
@@ -26,6 +26,7 @@ export interface EditorLayoutSlotsOptions {
   workspace: EditorWorkspace;
   preferredLeftTab?: 'objects' | 'polish';
   previewDocument?: RenderableDocument;
+  previewCamera?: CameraNode;
   previewMode: EditorStateMachinePreviewMode;
   timelinePreviewCallbacks: EditorTimelinePreviewCallbacks;
   colorScheme?: string;
@@ -85,7 +86,7 @@ export function useEditorLayoutComposition({
   });
   const { themeVars, colorScheme } = resolveEditorThemeVars(theme, editorTheme, state.themeOverrides);
   const liveDocument = activeDocument;
-  const { previewDocument, stateMachinePreviewMode, timelinePreviewCallbacks } = useEditorPreviewController(liveDocument);
+  const { previewDocument, previewCamera, stateMachinePreviewMode, timelinePreviewCallbacks } = useEditorPreviewController(liveDocument);
   const anchorCanvasForLeftOffsetChange = useCallback((currentLeftOffset: number, nextLeftOffset: number) => {
     const delta = currentLeftOffset - nextLeftOffset;
     if (delta !== 0) {
@@ -103,6 +104,7 @@ export function useEditorLayoutComposition({
     workspace: shell.workspace,
     preferredLeftTab: shell.preferredLeftTab,
     previewDocument,
+    previewCamera,
     previewMode: stateMachinePreviewMode,
     timelinePreviewCallbacks,
     colorScheme,
@@ -140,6 +142,7 @@ export function buildEditorLayoutSlots({
   workspace,
   preferredLeftTab,
   previewDocument,
+  previewCamera,
   previewMode,
   timelinePreviewCallbacks,
   colorScheme,
@@ -153,6 +156,7 @@ export function buildEditorLayoutSlots({
     canvas: (
       <EditorCanvasPanel
         previewDocument={previewDocument}
+        previewCamera={previewCamera}
         previewMode={previewMode}
         editorColorScheme={colorScheme}
         contentTheme={contentTheme}

--- a/packages/editor/src/state/reducer.ts
+++ b/packages/editor/src/state/reducer.ts
@@ -111,7 +111,9 @@ function syncCanonicalTimelines(
     if (tracks.length < timeline.tracks.length) {
       warnings.push(`Timeline "${id}" has ${timeline.tracks.length - tracks.length} track(s) targeting missing elements and will be omitted from document output.`);
     }
-    if (tracks.length > 0) nextTimelines[id] = { ...timeline, tracks };
+    if (tracks.length > 0 || timeline.camera || timeline.tracks.length === 0) {
+      nextTimelines[id] = { ...timeline, tracks };
+    }
   }
   return { timelines: Object.keys(nextTimelines).length > 0 ? nextTimelines : undefined, warnings };
 }
@@ -594,6 +596,33 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
     case 'DESELECT_ALL':
       return state.selectedIds.length === 0 ? state : { ...state, selectedIds: [] };
 
+    case 'SET_CAMERA_FRAMING':
+      if (!action.framing) {
+        return !state.isCameraFraming && !state.cameraFramingTimelineId && state.cameraFramingFrame === undefined
+          ? state
+          : {
+              ...state,
+              isCameraFraming: false,
+              cameraFramingTimelineId: undefined,
+              cameraFramingFrame: undefined,
+            };
+      }
+      return state.isCameraFraming
+        && state.cameraFramingTimelineId === action.timelineId
+        && state.cameraFramingFrame === action.frame
+        ? state
+        : {
+            ...state,
+            isCameraFraming: true,
+            cameraFramingTimelineId: action.timelineId,
+            cameraFramingFrame: action.frame,
+          };
+
+    case 'SET_ACTIVE_TIMELINE':
+      return state.activeTimelineId === action.timelineId
+        ? state
+        : { ...state, activeTimelineId: action.timelineId };
+
     case 'IMPORT_RENDERABLE_DOCUMENT':
       return {
         ...state,
@@ -617,6 +646,24 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
         canonicalDocument: action.document,
         compatibilityWarnings: action.warnings ?? [],
       };
+
+    case 'UPDATE_TIMELINE_CAMERA': {
+      const canonicalDocument = state.canonicalDocument;
+      const timeline = canonicalDocument?.timelines?.[action.timelineId];
+      if (!canonicalDocument || !timeline) return state;
+      const nextCanonicalDocument: CanonicalElucimDocument = {
+        ...canonicalDocument,
+        timelines: {
+          ...canonicalDocument.timelines,
+          [action.timelineId]: { ...timeline, camera: action.camera },
+        },
+      };
+      const projectedDocument = createRenderableDocument(nextCanonicalDocument);
+      return syncCanonicalFromProjection(
+        { ...state, canonicalDocument: nextCanonicalDocument, compatibilityWarnings: [] },
+        documentsEqual(projectedDocument, state.document) ? state.document : projectedDocument,
+      );
+    }
 
     case 'UPDATE_ELEMENT': {
       const doc = cloneDoc(state.document);

--- a/packages/editor/src/state/types.ts
+++ b/packages/editor/src/state/types.ts
@@ -1,4 +1,4 @@
-import type { ElucimDocument as CanonicalElucimDocument, RenderableDocument as ElucimDocument, ElementNode, SceneNode, PlayerNode } from '@elucim/dsl';
+import type { CameraTrack, ElucimDocument as CanonicalElucimDocument, ElucimTimeline, RenderableDocument as ElucimDocument, ElementNode, SceneNode, PlayerNode } from '@elucim/dsl';
 
 // ─── Editor State ──────────────────────────────────────────────────────────
 
@@ -36,6 +36,14 @@ export interface EditorState {
   activeTool: EditorTool;
   /** Whether user is currently panning (Space held) */
   isPanning: boolean;
+  /** Whether the canvas is showing the full scene for camera framing authoring. */
+  isCameraFraming: boolean;
+  /** Timeline selected by the animation or state-machine workspace. */
+  activeTimelineId?: string;
+  /** Timeline that owns the camera edit currently in progress. */
+  cameraFramingTimelineId?: string;
+  /** Frame that owns the camera edit currently in progress. */
+  cameraFramingFrame?: number;
   /** Floating toolbar position */
   toolbarPosition: PanelPosition;
   /** Floating inspector position (null = auto-position near selection) */
@@ -102,6 +110,9 @@ export type EditorAction =
   | { type: 'SET_PLAYING'; playing: boolean }
   | { type: 'SET_TOOL'; tool: EditorTool }
   | { type: 'SET_PANNING'; panning: boolean }
+  | { type: 'SET_CAMERA_FRAMING'; framing: boolean; timelineId?: string; frame?: number }
+  | { type: 'SET_ACTIVE_TIMELINE'; timelineId?: string }
+  | { type: 'UPDATE_TIMELINE_CAMERA'; timelineId: string; camera: CameraTrack }
   | { type: 'SET_TOOLBAR_POSITION'; position: PanelPosition }
   | { type: 'SET_TOOLBAR_COLLAPSED'; collapsed: boolean }
   | { type: 'SET_INSPECTOR_POSITION'; position: PanelPosition | null }
@@ -157,6 +168,10 @@ export function createInitialState(document?: ElucimDocument, initialFrame?: num
     isPlaying: false,
     activeTool: 'select',
     isPanning: false,
+    isCameraFraming: false,
+    activeTimelineId: undefined,
+    cameraFramingTimelineId: undefined,
+    cameraFramingFrame: undefined,
     toolbarPosition: { x: 24, y: 24 },
     inspectorPosition: null,
     inspectorPinned: true,
@@ -176,6 +191,7 @@ export function isUndoableAction(action: EditorAction): boolean {
   switch (action.type) {
     case 'UPDATE_ELEMENT':
     case 'UPDATE_CANVAS':
+    case 'UPDATE_TIMELINE_CAMERA':
     case 'ADD_ELEMENT':
     case 'DELETE_ELEMENTS':
     case 'DUPLICATE_ELEMENTS':

--- a/packages/editor/src/theme/tokens.ts
+++ b/packages/editor/src/theme/tokens.ts
@@ -20,6 +20,7 @@ export const EDITOR_TOKENS: Record<string, string> = {
   '--elucim-editor-surface':         '#12122a',
   '--elucim-editor-panel':           'rgba(22, 22, 42, 0.93)',
   '--elucim-editor-chrome':          'rgba(15, 23, 42, 0.8)',
+  '--elucim-editor-overlay':         'rgba(2, 6, 23, 0.58)',
 
   // ── Text ──────────────────────────────────────────────────────────────
   '--elucim-editor-fg':              '#e0e0e0',
@@ -63,6 +64,7 @@ export const EDITOR_TOKENS_LIGHT: Record<string, string> = {
   '--elucim-editor-surface':         '#ffffff',
   '--elucim-editor-panel':           'rgba(255, 255, 255, 0.95)',
   '--elucim-editor-chrome':          'rgba(241, 245, 249, 0.9)',
+  '--elucim-editor-overlay':         'rgba(15, 23, 42, 0.28)',
   '--elucim-editor-fg':              '#1e293b',
   '--elucim-editor-text-secondary':  '#334155',
   '--elucim-editor-text-muted':      '#64748b',

--- a/packages/editor/src/timeline/Timeline.tsx
+++ b/packages/editor/src/timeline/Timeline.tsx
@@ -95,18 +95,47 @@ function createUniqueStateMachineId(existing: Record<string, ElucimStateMachine>
   return `${preferred}-${index}`;
 }
 
+export function clampTimelineKeyframesToDuration(clip: ElucimTimeline, duration: number): ElucimTimeline {
+  const nextDuration = Math.max(1, Math.round(duration));
+  const clampKeyframes = <Keyframe extends { frame: number }>(keyframes: Keyframe[]): Keyframe[] => {
+    const clamped: Keyframe[] = [];
+    for (const keyframe of keyframes) {
+      const next = { ...keyframe, frame: Math.min(keyframe.frame, nextDuration) };
+      if (clamped[clamped.length - 1]?.frame === next.frame) {
+        clamped[clamped.length - 1] = next;
+      } else {
+        clamped.push(next);
+      }
+    }
+    return clamped;
+  };
+
+  return {
+    ...clip,
+    duration: nextDuration,
+    tracks: clip.tracks.map(track => ({ ...track, keyframes: clampKeyframes(track.keyframes) })),
+    ...(clip.camera ? {
+      camera: { ...clip.camera, keyframes: clampKeyframes(clip.camera.keyframes) },
+    } : {}),
+  };
+}
+
 function normalizeGraphId(value: string, fallback: string): string {
   const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
   return normalized || fallback;
 }
 
-function previewFramesEqual(
+export function previewFramesEqual(
   left: ElucimTimelineFrameSelection[] | undefined,
   right: ElucimTimelineFrameSelection[] | undefined,
 ): boolean {
   if (left === right) return true;
   if (!left || !right || left.length !== right.length) return false;
-  return left.every((frame, index) => frame.timelineId === right[index].timelineId && frame.frame === right[index].frame);
+  return left.every((frame, index) => (
+    frame.timelineId === right[index].timelineId
+    && frame.frame === right[index].frame
+    && (frame.applyCamera !== false) === (right[index].applyCamera !== false)
+  ));
 }
 
 /**
@@ -302,10 +331,15 @@ export function Timeline({
 
   const handleActiveTimelineChange = useCallback((timelineId: string | undefined) => {
     setActiveTimelineId(timelineId);
+    dispatch({ type: 'SET_ACTIVE_TIMELINE', timelineId });
     const nextMaxFrame = timelineId && activeTimelines?.[timelineId] ? activeTimelines[timelineId].duration : (showLegacyElementTracks ? durationInFrames : timelineDurationFallback) - 1;
     if (currentFrame > nextMaxFrame) dispatch({ type: 'SET_FRAME', frame: nextMaxFrame });
     onActiveTimelineChange?.(timelineId);
   }, [currentFrame, dispatch, durationInFrames, onActiveTimelineChange, showLegacyElementTracks, timelineDurationFallback, activeTimelines]);
+
+  useEffect(() => {
+    dispatch({ type: 'SET_ACTIVE_TIMELINE', timelineId: effectiveActiveTimelineId });
+  }, [dispatch, effectiveActiveTimelineId]);
 
   const previewStateAnimation = useCallback((machineId: string, stateId: string, details?: { event?: string; previousStateId?: string; activeTransitionId?: string }) => {
     const timelineId = activeStateMachines?.[machineId]?.states[stateId]?.timeline;
@@ -1109,15 +1143,7 @@ function TimelineClipRows({
     if (machine) renameMachine(machine, value);
   };
   const updateDuration = (clip: ElucimTimeline, duration: number) => {
-    const nextDuration = Math.max(1, Math.round(duration));
-    onTimelineChange?.({
-      ...clip,
-      duration: nextDuration,
-      tracks: clip.tracks.map(track => ({
-        ...track,
-        keyframes: track.keyframes.map(keyframe => ({ ...keyframe, frame: Math.min(keyframe.frame, nextDuration) })),
-      })),
-    });
+    onTimelineChange?.(clampTimelineKeyframesToDuration(clip, duration));
   };
   const renameClip = (clip: ElucimTimeline, value: string) => {
     const baseId = normalizeGraphId(value, clip.id);
@@ -1799,7 +1825,7 @@ function TimelineClipRows({
             </div>
             <div style={{ minWidth: 0, display: 'grid', gridTemplateRows: '20px 1fr' }}>
               <div style={{ minWidth: 0, display: 'flex', alignItems: 'center', paddingRight: 8 }}>
-                <div style={{ color: v('--elucim-editor-text-secondary'), fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                <div style={{ color: v('--elucim-editor-text-secondary'), fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {clip.id} - {clip.duration}f - {clip.tracks.length} track{clip.tracks.length === 1 ? '' : 's'}
                 </div>
               </div>

--- a/packages/editor/src/timeline/cameraKeyframes.ts
+++ b/packages/editor/src/timeline/cameraKeyframes.ts
@@ -1,0 +1,47 @@
+import type { CameraNode, ElucimTimeline } from '@elucim/dsl';
+
+export interface SceneCameraViewport {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Replaces or inserts one camera sample without changing the timeline's
+ * coordinate space or fit mode.
+ */
+export function upsertTimelineCameraKeyframe(
+  timeline: ElucimTimeline,
+  sourceCamera: CameraNode | undefined,
+  frame: number,
+  sceneViewport: SceneCameraViewport,
+  sceneWidth: number,
+  sceneHeight: number,
+): ElucimTimeline {
+  const coordinateSpace = timeline.camera?.coordinateSpace ?? sourceCamera?.coordinateSpace ?? 'scene';
+  const keyframeFrame = Math.max(0, Math.min(frame, timeline.duration));
+  const viewport = coordinateSpace === 'normalized'
+    ? {
+        x: sceneViewport.x / sceneWidth,
+        y: sceneViewport.y / sceneHeight,
+        width: sceneViewport.width / sceneWidth,
+        height: sceneViewport.height / sceneHeight,
+      }
+    : { ...sceneViewport };
+  const keyframes = [
+    ...(timeline.camera?.keyframes ?? []),
+    { frame: keyframeFrame, viewport },
+  ]
+    .filter((keyframe, index, all) => keyframe.frame !== keyframeFrame || index === all.length - 1)
+    .sort((left, right) => left.frame - right.frame);
+
+  return {
+    ...timeline,
+    camera: {
+      coordinateSpace,
+      fit: timeline.camera?.fit ?? sourceCamera?.fit ?? 'cover',
+      keyframes,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add semantic `timeline.camera` keyframes with scene/normalized viewports, fit modes, and easing
- render evaluated cameras consistently in browser, SVG/PNG export, state machines, and editor previews
- add timeline-native editor camera framing and camera-aware selection interactions
- remove the unused static scene/render-tree camera paths

## Validation
- `pnpm --filter @elucim/dsl test`
- `pnpm --filter @elucim/editor test`
- `pnpm --filter @elucim/dsl build`
- `pnpm --filter @elucim/editor build`
- `pnpm exec playwright test tests/scene-camera.spec.ts --reporter=line`