### PR TITLE
feat: add timeline reveal effects

### DIFF
--- a/docs/src/content/docs/dsl/agent-documents.mdx
+++ b/docs/src/content/docs/dsl/agent-documents.mdx
@@ -157,7 +157,28 @@ const playable = createLoopingStateMachine(repaired.document, { timelineId: 'int
 
 ## Timelines and state machines
 
-Timelines are keyframe clips over a small safe property set: `opacity`, `translate`, `scale`, `rotate`, `fill`, and `stroke`.
+Timelines combine keyframe tracks with procedural `effects`. Tracks cover a small safe property set: `opacity`, `translate`, `scale`, `rotate`, `fill`, `stroke`, and text `content`. A `reveal` effect owns reveal timing, so keep full content on the text element and schedule an explicit effect whenever that phrase should appear. `strategy: 'auto'` types text and fades other current primitives; group targets expand to leaf descendants in child order and can use `staggerInFrames`.
+
+```ts
+timelines: {
+  intro: {
+    id: 'intro',
+    duration: 72,
+    tracks: [],
+    effects: [{
+      id: 'headline-reveal',
+      kind: 'reveal',
+      targets: ['headline'],
+      from: 12,
+      duration: 36,
+      strategy: 'auto',
+      cursor: { character: '|' },
+    }],
+  },
+}
+```
+
+Do not add a `typing` property to text. A `content` track does not implicitly restart a reveal; add another reveal effect with the desired start and duration instead.
 
 ```ts
 import { applyTimelineFrame, transitionStateMachine } from '@elucim/dsl';

--- a/docs/src/content/docs/dsl/overview.mdx
+++ b/docs/src/content/docs/dsl/overview.mdx
@@ -160,7 +160,7 @@ Every node has a `"type"` field. The full set of supported types:
 |------|-------------|
 | `scene` | Root scene/player settings with top-level child element IDs |
 | `elements` | ID-keyed primitive/group definitions |
-| `timelines` | Explicit property tracks and keyframes |
+| `timelines` | Explicit property tracks, keyframes, and procedural effects |
 | `stateMachines` | Entry/state/transition controllers for interactive playback |
 
 ### Primitive Nodes

--- a/docs/src/content/docs/primitives/text.mdx
+++ b/docs/src/content/docs/primitives/text.mdx
@@ -51,3 +51,17 @@ Use `textAnchor="middle"` when centering text on a known x coordinate — this a
 :::tip
 Use [`textbox`](/primitives/textbox/) instead of loose `text` when generated copy must stay within a known rectangle.
 :::
+
+## Typing and text reveal
+
+Text remains a normal SVG layer. Use the shared `Reveal` animation to supply deterministic frame progress; `strategy="type"` reveals grapheme clusters and shows a cursor until the reveal completes.
+
+```tsx
+<Reveal from={12} durationInFrames={48} strategy="type" cursor={{ character: '|' }}>
+  <Text x={80} y={140} fontSize={28}>
+    Deploying your workspace...
+  </Text>
+</Reveal>
+```
+
+Set `cursor: false` to reveal text without a cursor. Canonical DSL documents use timeline `effects` instead of `Reveal`; both paths resolve the same primitive reveal state.

--- a/packages/core/src/__tests__/text.test.tsx
+++ b/packages/core/src/__tests__/text.test.tsx
@@ -3,6 +3,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import { Scene } from '../components/Scene';
 import { Text } from '../primitives/Text';
+import { measureTextWidth } from '../text/measureText';
+import { Reveal } from '../animations/Reveal';
 
 describe('Text', () => {
   function renderText(text: React.ReactElement) {
@@ -46,5 +48,98 @@ describe('Text', () => {
     );
 
     expect(html).toContain('<tspan x="10" dy="15">cd</tspan>');
+  });
+
+  it('reveals text deterministically and hides its cursor when complete', () => {
+    const initial = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={0}>
+        <Reveal strategy="type" durationInFrames={4}>
+          <Text x={10} y={20}>Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+    const midway = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={2}>
+        <Reveal strategy="type" durationInFrames={4}>
+          <Text x={10} y={20}>Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+    const complete = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={4}>
+        <Reveal strategy="type" durationInFrames={4}>
+          <Text x={10} y={20}>Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+
+    expect(initial).toContain('data-testid="elucim-text-cursor"');
+    expect(midway).toContain('>He</text>');
+    expect(midway).toContain('data-testid="elucim-text-cursor">|</text>');
+    expect(complete).toContain('>Hello</text>');
+    expect(complete).not.toContain('elucim-text-cursor');
+  });
+
+  it('supports a delayed reveal and persistent custom cursor', () => {
+    const html = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={3}>
+        <Reveal strategy="type" from={2} durationInFrames={3} cursor={{ character: '_', hideWhenComplete: false }}>
+          <Text x={10} y={20}>Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+
+    expect(html).toContain('>H</text>');
+    expect(html).toContain('data-testid="elucim-text-cursor">_</text>');
+  });
+
+  it('blinks a reveal cursor from the current frame', () => {
+    const hidden = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={1}>
+        <Reveal strategy="type" durationInFrames={4} cursor={{ blinkEveryFrames: 1 }}>
+          <Text x={10} y={20}>Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+    const visible = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={2}>
+        <Reveal strategy="type" durationInFrames={4} cursor={{ blinkEveryFrames: 1 }}>
+          <Text x={10} y={20}>Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+
+    expect(hidden).not.toContain('elucim-text-cursor');
+    expect(visible).toContain('data-testid="elucim-text-cursor">|</text>');
+  });
+
+  it('positions a cursor after centered text and at the end anchor without shifting the text', () => {
+    const centered = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={2}>
+        <Reveal strategy="type" durationInFrames={4}>
+          <Text x={100} y={20} textAnchor="middle">Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+    const endAligned = renderToStaticMarkup(
+      <Scene durationInFrames={20} frame={2}>
+        <Reveal strategy="type" durationInFrames={4}>
+          <Text x={100} y={20} textAnchor="end">Hello</Text>
+        </Reveal>
+      </Scene>,
+    );
+
+    const centeredCursorX = 100 + measureTextWidth('He', {
+      fontSize: 24,
+      fontFamily: 'sans-serif',
+      fontWeight: 'normal',
+    }) / 2;
+
+    expect(centered).toContain('text-anchor="middle"');
+    expect(centered).toMatch(
+      new RegExp(`<text x="${centeredCursorX}"[^>]*data-testid="elucim-text-cursor"`),
+    );
+    expect(endAligned).toContain('text-anchor="end"');
+    expect(endAligned).toMatch(/<text x="100"[^>]*data-testid="elucim-text-cursor"/);
   });
 });

--- a/packages/core/src/animations/Reveal.tsx
+++ b/packages/core/src/animations/Reveal.tsx
@@ -1,0 +1,84 @@
+import React, { createContext, useContext } from 'react';
+import { useCurrentFrame } from '../hooks/useCurrentFrame';
+
+export type RevealStrategy = 'type' | 'fade';
+
+export interface RevealCursorOptions {
+  character?: string;
+  blinkEveryFrames?: number;
+  hideWhenComplete?: boolean;
+}
+
+/**
+ * A resolved reveal assignment supplied by a timeline or a React animation.
+ * Primitives consume progress; timeline scheduling remains outside primitives.
+ */
+export interface RevealState {
+  progress: number;
+  strategy: RevealStrategy;
+  cursor?: boolean | RevealCursorOptions;
+}
+
+export interface RevealProps {
+  children: React.ReactNode;
+  durationInFrames: number;
+  from?: number;
+  strategy?: RevealStrategy;
+  cursor?: boolean | RevealCursorOptions;
+}
+
+const RevealContext = createContext<RevealState | undefined>(undefined);
+
+export function useRevealState(): RevealState | undefined {
+  return useContext(RevealContext);
+}
+
+export function RevealStateProvider({
+  state,
+  children,
+}: {
+  state: RevealState;
+  children: React.ReactNode;
+}) {
+  const opacity = state.strategy === 'fade' ? state.progress : 1;
+  return (
+    <RevealContext.Provider value={state}>
+      <g opacity={opacity}>{children}</g>
+    </RevealContext.Provider>
+  );
+}
+
+/**
+ * React authoring wrapper for a single reveal interval.
+ *
+ * Canonical documents use timeline effects instead, but both paths provide the
+ * same resolved state to primitives.
+ */
+export function Reveal({
+  children,
+  durationInFrames,
+  from = 0,
+  strategy = 'fade',
+  cursor,
+}: RevealProps) {
+  if (!Number.isInteger(durationInFrames) || durationInFrames <= 0) {
+    throw new Error('Reveal durationInFrames must be a positive integer.');
+  }
+  if (!Number.isInteger(from) || from < 0) {
+    throw new Error('Reveal from must be a non-negative integer.');
+  }
+
+  const frame = useCurrentFrame();
+  const progress = Math.max(0, Math.min(1, (frame - from) / durationInFrames));
+  const elapsedFrames = Math.max(0, frame - from);
+  const resolvedCursor = typeof cursor === 'object'
+    && cursor.blinkEveryFrames
+    && Math.floor(elapsedFrames / cursor.blinkEveryFrames) % 2 === 1
+    ? false
+    : cursor;
+  return (
+    <RevealStateProvider state={{ progress, strategy, cursor: resolvedCursor }}>
+      {children}
+    </RevealStateProvider>
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,12 +72,20 @@ export {
   type MeasureTextOptions,
   type TextWrapMode,
 } from './text/measureText';
-
 // Legacy animation wrappers
 export { FadeIn, FadeOut, type FadeInProps, type FadeOutProps } from './animations/Fade';
 export { Draw, Write, type DrawProps, type WriteProps } from './animations/DrawWrite';
 export { Transform, Morph, type TransformProps, type MorphProps } from './animations/Transform';
 export { Parallel, Stagger, type ParallelProps, type StaggerProps } from './animations/Groups';
+export {
+  Reveal,
+  RevealStateProvider,
+  useRevealState,
+  type RevealCursorOptions,
+  type RevealProps,
+  type RevealState,
+  type RevealStrategy,
+} from './animations/Reveal';
 
 // Theme
 export {

--- a/packages/core/src/primitives/Text.tsx
+++ b/packages/core/src/primitives/Text.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useAnimation, type AnimationProps } from './animation';
 import { withTransform, type SpatialProps, type BaseElementProps } from './transform';
-import { measureTextLayout, type TextWrapMode } from '../text/measureText';
+import { measureTextLayout, measureTextWidth, type TextWrapMode } from '../text/measureText';
+import { useRevealState, type RevealCursorOptions } from '../animations/Reveal';
 
 export interface TextProps extends AnimationProps, SpatialProps, BaseElementProps {
   x: number;
@@ -42,20 +43,25 @@ export function Text({
   translate,
 }: TextProps) {
   const anim = useAnimation({ fadeIn, fadeOut, easing });
+  const reveal = useRevealState();
+  const revealState = reveal?.strategy === 'type'
+    ? resolveTextReveal(children, reveal.progress, reveal.cursor)
+    : { content: children };
+  const content = revealState.content;
   const shouldUseLayout = maxWidth !== undefined || lineHeight !== undefined || wrap !== undefined;
   const layout = shouldUseLayout
-    ? measureTextLayout(children, { fontSize, fontFamily, fontWeight, lineHeight, maxWidth, wrap })
+    ? measureTextLayout(content, { fontSize, fontFamily, fontWeight, lineHeight, maxWidth, wrap })
     : undefined;
-  const shouldRenderLines = layout !== undefined && (layout.lines.length !== 1 || layout.lines[0]?.text !== children);
+  const shouldRenderLines = layout !== undefined && (layout.lines.length !== 1 || layout.lines[0]?.text !== content);
   const renderedContent = shouldRenderLines && layout
     ? layout.lines.map((line, index) => (
       <tspan key={index} x={x} dy={index === 0 ? 0 : layout.lineHeight}>
         {line.text}
       </tspan>
     ))
-    : children;
+    : content;
 
-  const el = (
+  const textEl = (
     <text
       x={x}
       y={y}
@@ -71,6 +77,55 @@ export function Text({
       {renderedContent}
     </text>
   );
+  const cursorLineIndex = shouldRenderLines && layout ? Math.max(0, layout.lines.length - 1) : 0;
+  const cursorLine = shouldRenderLines && layout
+    ? layout.lines[cursorLineIndex] ?? { text: '', width: 0 }
+    : { text: content, width: measureTextWidth(content, { fontSize, fontFamily, fontWeight }) };
+  const cursorX = textAnchor === 'middle'
+    ? x + cursorLine.width / 2
+    : textAnchor === 'end'
+      ? x
+      : x + cursorLine.width;
+  const cursorY = y + (shouldRenderLines && layout ? cursorLineIndex * layout.lineHeight : 0);
+  const el = revealState.cursor ? (
+    <g>
+      {textEl}
+      <text
+        x={cursorX}
+        y={cursorY}
+        fill={fill}
+        fontSize={fontSize}
+        fontFamily={fontFamily}
+        fontWeight={fontWeight}
+        dominantBaseline={dominantBaseline}
+        opacity={baseOpacity * anim.opacity}
+        data-testid="elucim-text-cursor"
+      >
+        {revealState.cursor}
+      </text>
+    </g>
+  ) : textEl;
 
   return withTransform(el, { rotation, rotationOrigin, scale, translate }, [x, y], [x, y]);
+}
+
+function resolveTextReveal(
+  content: string,
+  progress: number,
+  cursor: boolean | RevealCursorOptions | undefined,
+): { content: string; cursor?: string } {
+  const characters = Array.from(content);
+  const visibleCount = Math.floor(Math.max(0, Math.min(1, progress)) * characters.length);
+  const visibleContent = characters.slice(0, visibleCount).join('');
+  const complete = visibleCount >= characters.length;
+  const cursorOptions = cursor === false ? undefined : cursor ?? true;
+  const hideWhenComplete = typeof cursorOptions === 'object'
+    ? cursorOptions.hideWhenComplete ?? true
+    : true;
+  if (!cursorOptions || (complete && hideWhenComplete)) return { content: visibleContent };
+
+  return {
+    content: visibleContent,
+    cursor: typeof cursorOptions === 'object' ? cursorOptions.character ?? '|' : '|',
+  };
 }

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Transform as AnimTransform,
   Morph,
   Stagger,
+  Reveal,
   interpolate,
   useCurrentFrame,
   easeOutCubic,
@@ -284,7 +285,7 @@ function RectDemo() {
 function TextDemo() {
   return (
     <section id="text-demo">
-      <h2 style={{ padding: '16px 0 8px' }}>Text — FadeIn</h2>
+      <h2 style={{ padding: '16px 0 8px' }}>Text — FadeIn &amp; reveal</h2>
       <Player
         width={400}
         height={200}
@@ -292,9 +293,19 @@ function TextDemo() {
         durationInFrames={60}
         background="#111127"
       >
-        <Text x={200} y={100} fill="#a29bfe" fontSize={36} textAnchor="middle" dominantBaseline="middle" fadeIn={30}>
-          Hello Elucim
-        </Text>
+        <Reveal strategy="type" durationInFrames={24}>
+          <Text
+            x={200}
+            y={100}
+            fill="#a29bfe"
+            fontSize={36}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fadeIn={15}
+          >
+            Hello Elucim
+          </Text>
+        </Reveal>
       </Player>
     </section>
   );

--- a/packages/dsl/src/__tests__/documentStateMachine.test.ts
+++ b/packages/dsl/src/__tests__/documentStateMachine.test.ts
@@ -148,9 +148,9 @@ describe('document state machines', () => {
     });
 
     expect(frames).toEqual([
-      { timelineId: 'idle', frame: 0 },
-      { timelineId: 'intro', frame: 0 },
-      { timelineId: 'outro', frame: 0 },
+      { timelineId: 'idle', frame: 0, includeContent: false },
+      { timelineId: 'intro', frame: 0, includeContent: false },
+      { timelineId: 'outro', frame: 0, includeContent: false },
       { timelineId: 'idle', frame: 1 },
       { timelineId: 'intro', frame: 12 },
     ]);
@@ -165,9 +165,9 @@ describe('document state machines', () => {
     });
 
     expect(frames).toEqual([
-      { timelineId: 'idle', frame: 0 },
-      { timelineId: 'intro', frame: 0 },
-      { timelineId: 'outro', frame: 0 },
+      { timelineId: 'idle', frame: 0, includeContent: false },
+      { timelineId: 'intro', frame: 0, includeContent: false },
+      { timelineId: 'outro', frame: 0, includeContent: false },
       { timelineId: 'idle', frame: 1 },
       { timelineId: 'intro', frame: 12 },
     ]);
@@ -365,9 +365,9 @@ describe('document state machines', () => {
     const waiting = startStateMachineRun(gated, 'presentation');
     expect(waiting).toMatchObject({ stateId: 'entry', playing: false, statePath: [] });
     expect(getStateMachineRunVisualFrames(gated, waiting)).toEqual([
-      { timelineId: 'idle', frame: 0 },
-      { timelineId: 'intro', frame: 0 },
-      { timelineId: 'outro', frame: 0 },
+      { timelineId: 'idle', frame: 0, includeContent: false },
+      { timelineId: 'intro', frame: 0, includeContent: false },
+      { timelineId: 'outro', frame: 0, includeContent: false },
     ]);
 
     const idle = dispatchStateMachineRunEvent(gated, waiting, 'onClick');

--- a/packages/dsl/src/__tests__/documentTimeline.test.ts
+++ b/packages/dsl/src/__tests__/documentTimeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyCommand, applyTimelineFrame, applyTimelineFrames, createRenderableDocument, evaluateTimeline, validateDocument, type ElucimDocument } from '../index';
+import { applyCommand, applyTimelineFrame, applyTimelineFrames, createRenderableDocument, evaluateTimeline, resolveTimelineReveals, validateDocument, type ElucimDocument } from '../index';
 
 const doc: ElucimDocument = {
   version: '2.0',
@@ -53,6 +53,150 @@ describe('document timelines and keyframes', () => {
     expect(frame.title.props?.opacity).toBe(0.5);
     expect(frame.title.layout?.translate).toEqual([0, 12]);
     expect(frame.title.props?.fill).toBe('#808080');
+  });
+
+  it('applies text content timeline tracks without mutating the source document', () => {
+    const next = applyTimelineFrame({
+      ...doc,
+      timelines: {
+        typing: {
+          id: 'typing',
+          duration: 20,
+          tracks: [{ target: 'title', property: 'content', keyframes: [{ frame: 0, value: '' }, { frame: 20, value: 'Hello' }] }],
+        },
+      },
+    }, 'typing', 20);
+
+    expect(next.elements.title.props.content).toBe('Hello');
+    expect(doc.elements.title.props.content).toBe('Hello');
+  });
+
+  it('validates content tracks only for text targets with string keyframes', () => {
+    const result = validateDocument({
+      ...doc,
+      timelines: {
+        invalid: {
+          id: 'invalid',
+          duration: 10,
+          tracks: [{ target: 'title', property: 'content', keyframes: [{ frame: 0, value: 1 }] }],
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(error => error.path)).toContain('timelines.invalid.tracks[0].keyframes[0].value');
+  });
+
+  it('resolves explicit reveal effects for text and group descendants', () => {
+      const revealDoc: ElucimDocument = {
+        ...doc,
+        scene: { ...doc.scene, children: ['group'] },
+        elements: {
+          ...doc.elements,
+          group: { id: 'group', type: 'group', children: ['title', 'subtitle'], props: {} },
+          subtitle: { id: 'subtitle', type: 'rect', parentId: 'group', props: { type: 'rect', x: 0, y: 0, width: 10, height: 10 } },
+          title: { ...doc.elements.title, parentId: 'group' },
+        },
+        timelines: {
+          intro: {
+            id: 'intro',
+            duration: 12,
+            tracks: [],
+            effects: [{
+              id: 'reveal-group',
+              kind: 'reveal',
+              targets: ['group'],
+              from: 2,
+              duration: 4,
+              staggerInFrames: 2,
+              cursor: { character: '_' },
+            }],
+          },
+        },
+      };
+
+      const reveals = resolveTimelineReveals(revealDoc, [{ timelineId: 'intro', frame: 4 }]);
+
+      expect(reveals.title).toEqual({ progress: 0.5, strategy: 'type', cursor: { character: '_' } });
+      expect(reveals.subtitle).toEqual({ progress: 0, strategy: 'fade', cursor: { character: '_' } });
+      expect(validateDocument(revealDoc).valid).toBe(true);
+    });
+
+    it('rejects reveal effects that overrun their timeline', () => {
+      const result = validateDocument({
+        ...doc,
+        timelines: {
+          intro: {
+            id: 'intro',
+            duration: 5,
+            tracks: [],
+            effects: [{ id: 'late', kind: 'reveal', targets: ['title'], from: 3, duration: 3 }],
+          },
+        },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(error => error.path === 'timelines.intro.effects[0]')).toBe(true);
+  });
+
+  it('keeps the latest started reveal effect for repeated targets', () => {
+      const revealDoc: ElucimDocument = {
+        ...doc,
+        timelines: {
+          intro: {
+            id: 'intro',
+            duration: 10,
+            tracks: [],
+            effects: [
+              { id: 'first', kind: 'reveal', targets: ['title'], from: 0, duration: 2 },
+              { id: 'second', kind: 'reveal', targets: ['title'], from: 5, duration: 3 },
+            ],
+          },
+        },
+      };
+
+      expect(resolveTimelineReveals(revealDoc, [{ timelineId: 'intro', frame: 3 }]).title.progress).toBe(1);
+      expect(resolveTimelineReveals(revealDoc, [{ timelineId: 'intro', frame: 5 }]).title.progress).toBe(0);
+  });
+
+  it('accepts effect-only timelines while rejecting incomplete or incompatible effects', () => {
+      const effectOnly: ElucimDocument = {
+        ...doc,
+        timelines: {
+          intro: {
+            id: 'intro',
+            duration: 5,
+            tracks: [],
+            effects: [{ id: 'fade', kind: 'reveal', targets: ['title'], from: 0, duration: 5, strategy: 'fade' }],
+          },
+        },
+      };
+      const malformed = {
+        ...effectOnly,
+        timelines: {
+          intro: {
+            ...effectOnly.timelines!.intro,
+            effects: [{ id: 'missing-timing', kind: 'reveal', targets: ['title'] }],
+          },
+        },
+      };
+      const invalidStrategy = {
+        ...effectOnly,
+        elements: {
+          ...effectOnly.elements,
+          box: { id: 'box', type: 'rect', props: { type: 'rect', x: 0, y: 0, width: 1, height: 1 } },
+        },
+        timelines: {
+          intro: {
+            ...effectOnly.timelines!.intro,
+            effects: [{ id: 'wrong-strategy', kind: 'reveal', targets: ['box'], from: 0, duration: 5, strategy: 'type' }],
+          },
+        },
+      };
+
+      expect(validateDocument(effectOnly).valid).toBe(true);
+      expect(() => applyTimelineFrame(effectOnly, 'intro', 2)).not.toThrow();
+      expect(validateDocument(malformed).valid).toBe(false);
+      expect(validateDocument(invalidStrategy).valid).toBe(false);
   });
 
   it('applies timeline frames without mutating the source document', () => {

--- a/packages/dsl/src/__tests__/dslRendererProps.test.tsx
+++ b/packages/dsl/src/__tests__/dslRendererProps.test.tsx
@@ -147,6 +147,234 @@ describe('DslRenderer player override props', () => {
     expect(container.querySelector('[data-testid="elucim-text"]')?.getAttribute('opacity')).toBe('0.75');
   });
 
+  it('drives a text reveal effect from the active state-machine timeline frame', () => {
+    const ref = React.createRef<DslRendererRef>();
+    const { container } = render(
+      <DslRenderer
+        ref={ref}
+        dsl={{
+          version: '2.0',
+          scene: { type: 'player', width: 400, height: 300, children: ['title'] },
+          elements: {
+            title: {
+              id: 'title',
+              type: 'text',
+              props: { type: 'text', x: 20, y: 40, content: 'Hello' },
+            },
+          },
+          timelines: {
+            intro: {
+              id: 'intro',
+              duration: 10,
+              tracks: [{ target: 'title', property: 'opacity', keyframes: [{ frame: 0, value: 1 }] }],
+              effects: [{ id: 'type-title', kind: 'reveal', targets: ['title'], from: 0, duration: 4 }],
+            },
+          },
+          defaultStateMachine: 'deck',
+          stateMachines: {
+            deck: {
+              id: 'deck',
+              entry: 'intro',
+              states: { intro: { timeline: 'intro' } },
+              transitions: [{ id: 'entry-start', from: 'entry', to: 'intro', trigger: 'onStart' }],
+            },
+          },
+        }}
+      />,
+    );
+
+    act(() => { ref.current!.seekToFrame(2); });
+
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+    expect(container.querySelector('[data-testid="elucim-text-cursor"]')?.textContent).toBe('|');
+  });
+
+  it('freezes completed reveal effects at their selected state frame', () => {
+    const ref = React.createRef<DslRendererRef>();
+    const { container } = render(
+      <DslRenderer
+        ref={ref}
+        dsl={{
+          version: '2.0',
+          scene: { type: 'player', width: 400, height: 300, children: ['title'] },
+          elements: {
+            title: {
+              id: 'title',
+              type: 'text',
+              props: { type: 'text', x: 20, y: 40, content: 'Hello' },
+            },
+          },
+          timelines: {
+            intro: {
+              id: 'intro',
+              duration: 6,
+              tracks: [{
+                target: 'title',
+                property: 'content',
+                keyframes: [{ frame: 0, value: 'Hello' }, { frame: 5, value: 'World' }],
+              }],
+              effects: [{ id: 'type-title', kind: 'reveal', targets: ['title'], from: 0, duration: 4 }],
+            },
+            outro: { id: 'outro', duration: 6, tracks: [] },
+          },
+          defaultStateMachine: 'deck',
+          stateMachines: {
+            deck: {
+              id: 'deck',
+              entry: 'intro',
+              states: { intro: { timeline: 'intro' }, outro: { timeline: 'outro' } },
+              transitions: [
+                { id: 'entry-start', from: 'entry', to: 'intro', trigger: 'onStart' },
+                { id: 'intro-next', from: 'intro', to: 'outro', trigger: 'onClick' },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    act(() => { ref.current!.seekToFrame(2); });
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+
+    fireEvent.click(container.querySelector('[data-testid="dsl-root"]')!);
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+
+    act(() => { ref.current!.seekToFrame(4); });
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+  });
+
+  it('uses a new effect to reveal text changed by a state timeline', () => {
+    const ref = React.createRef<DslRendererRef>();
+    const { container } = render(
+      <DslRenderer
+        ref={ref}
+        dsl={{
+          version: '2.0',
+          scene: { type: 'player', width: 400, height: 300, children: ['title'] },
+          elements: {
+            title: {
+              id: 'title',
+              type: 'text',
+              props: { type: 'text', x: 20, y: 40, content: 'Hello' },
+            },
+          },
+          timelines: {
+            intro: {
+              id: 'intro',
+              duration: 6,
+              tracks: [],
+              effects: [{ id: 'type-intro', kind: 'reveal', targets: ['title'], from: 0, duration: 4 }],
+            },
+            replacement: {
+              id: 'replacement',
+              duration: 6,
+              tracks: [{
+                target: 'title',
+                property: 'content',
+                keyframes: [
+                  { frame: 0, value: 'Hello' },
+                  { frame: 1, value: 'World' },
+                  { frame: 3, value: 'Hello' },
+                ],
+              }],
+              effects: [{ id: 'type-replacement', kind: 'reveal', targets: ['title'], from: 1, duration: 4 }],
+            },
+          },
+          defaultStateMachine: 'deck',
+          stateMachines: {
+            deck: {
+              id: 'deck',
+              entry: 'intro',
+              states: { intro: { timeline: 'intro' }, replacement: { timeline: 'replacement' } },
+              transitions: [
+                { id: 'entry-start', from: 'entry', to: 'intro', trigger: 'onStart' },
+                { id: 'intro-next', from: 'intro', to: 'replacement', trigger: 'onClick' },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    act(() => { ref.current!.seekToFrame(2); });
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+
+    fireEvent.click(container.querySelector('[data-testid="dsl-root"]')!);
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('');
+
+    act(() => { ref.current!.seekToFrame(1); });
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('');
+    expect(container.querySelector('[data-testid="elucim-text-cursor"]')?.textContent).toBe('|');
+
+    act(() => { ref.current!.seekToFrame(2); });
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('W');
+
+    act(() => { ref.current!.seekToFrame(3); });
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+    expect(container.querySelector('[data-testid="elucim-text-cursor"]')?.textContent).toBe('|');
+  });
+
+  it('renders canonical text reveal effects at the requested poster frame', () => {
+    const dsl = {
+      version: '2.0' as const,
+      scene: { type: 'player' as const, width: 400, height: 300, children: ['title'] },
+      elements: {
+        title: {
+          id: 'title',
+          type: 'text',
+          props: { type: 'text', x: 20, y: 40, content: 'Hello' },
+        },
+      },
+      timelines: {
+        intro: {
+          id: 'intro',
+          duration: 4,
+          tracks: [{ target: 'title', property: 'opacity' as const, keyframes: [{ frame: 0, value: 1 }] }],
+          effects: [{ id: 'type-title', kind: 'reveal' as const, targets: ['title'], from: 0, duration: 4 }],
+        },
+      },
+    };
+    const { container, rerender } = render(<DslRenderer dsl={dsl} poster={2} />);
+
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('He');
+    expect(container.querySelector('[data-testid="elucim-text-cursor"]')?.textContent).toBe('|');
+
+    rerender(<DslRenderer dsl={dsl} poster="last" />);
+
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('Hello');
+    expect(container.querySelector('[data-testid="elucim-text-cursor"]')).toBeNull();
+  });
+
+  it('uses an explicit effect to reveal content changed by a canonical poster timeline', () => {
+    const dsl = {
+      version: '2.0' as const,
+      scene: { type: 'player' as const, width: 400, height: 300, children: ['title'] },
+      elements: {
+        title: {
+          id: 'title',
+          type: 'text',
+          props: { type: 'text', x: 20, y: 40, content: 'Hello' },
+        },
+      },
+      timelines: {
+        intro: {
+          id: 'intro',
+          duration: 4,
+          tracks: [{
+            target: 'title',
+            property: 'content' as const,
+            keyframes: [{ frame: 0, value: 'Hello' }, { frame: 2, value: 'World' }],
+          }],
+          effects: [{ id: 'type-world', kind: 'reveal' as const, targets: ['title'], from: 2, duration: 2 }],
+        },
+      },
+    };
+    const { container } = render(<DslRenderer dsl={dsl} poster={2} />);
+
+    expect(container.querySelector('[data-testid="elucim-text"]')?.textContent).toBe('');
+    expect(container.querySelector('[data-testid="elucim-text-cursor"]')?.textContent).toBe('|');
+  });
+
   it('renders document state machines parsed from YAML in the viewer', () => {
     const dsl = fromYaml(`
 version: '2.0'

--- a/packages/dsl/src/__tests__/validate.test.ts
+++ b/packages/dsl/src/__tests__/validate.test.ts
@@ -109,6 +109,19 @@ describe('DSL Validator', () => {
       expect(result.valid).toBe(false);
     });
 
+    it('rejects the removed text-local typing property', () => {
+      const invalid = validate(wrap({
+        type: 'text',
+        x: 100,
+        y: 100,
+        content: 'Hello',
+        typing: { durationInFrames: 24 },
+      }));
+
+      expect(invalid.valid).toBe(false);
+      expect(invalid.errors.some(error => error.path.endsWith('.typing'))).toBe(true);
+    });
+
     it('accepts a valid polygon', () => {
       const result = validate(wrap({
         type: 'polygon',

--- a/packages/dsl/src/document.ts
+++ b/packages/dsl/src/document.ts
@@ -7,6 +7,9 @@ export type {
   ElucimLayout as ElucimLayout,
   ElucimAnimatableProperty as ElucimAnimatableProperty,
   ElucimKeyframe as ElucimKeyframe,
+  ElucimRevealCursor as ElucimRevealCursor,
+  ElucimRevealEffect as ElucimRevealEffect,
+  ElucimRevealStrategy as ElucimRevealStrategy,
   ElucimTimelineTrack as ElucimTimelineTrack,
   ElucimTimeline as ElucimTimeline,
   ElucimStateMachine as ElucimStateMachine,
@@ -70,6 +73,7 @@ export {
   applyTimelineFrame,
   applyTimelineFrames,
   evaluateTimeline,
+  resolveTimelineReveals,
 } from './documentModel/timeline';
 export {
   advanceStateMachineRunFrame,

--- a/packages/dsl/src/documentModel/stateMachine.ts
+++ b/packages/dsl/src/documentModel/stateMachine.ts
@@ -24,6 +24,7 @@ export interface ElucimStateEvent {
 export interface ElucimStateMachineVisualFrame {
   timelineId: string;
   frame: number;
+  includeContent?: boolean;
 }
 
 export interface ElucimStateMachineRun {
@@ -32,6 +33,8 @@ export interface ElucimStateMachineRun {
   timelineId?: string;
   statePath: string[];
   currentFrame: number;
+  /** Resolved local frames aligned with `statePath`. */
+  stateFrames: number[];
   playing: boolean;
   event?: string;
   previousStateId?: string;
@@ -53,6 +56,8 @@ export interface ElucimStateMachineRunResult extends ElucimStateMachineRun {
  */
 export interface ElucimStateMachineVisualFrameOptions {
   statePath?: string[];
+  /** Local elapsed frames for each state in `statePath`. */
+  stateFrames?: number[];
   currentStateId: string;
   currentFrame: number;
   exited?: boolean;
@@ -75,6 +80,7 @@ export function startStateMachineRun(doc: ElucimDocument, machineId: string): El
       stateId: 'entry',
       statePath: [],
       currentFrame: 0,
+      stateFrames: [],
       playing: false,
       event: 'start',
       activeTransitionId: entryTransition.id,
@@ -101,9 +107,11 @@ export function dispatchStateMachineRunEvent(
   if (!transition) {
     if ((eventName === 'complete' || eventName === 'next') && run.stateId !== 'entry') {
       const hasEventsToWaitFor = (machine.transitions ?? []).some(transition => transition.from === run.stateId && transition.trigger);
+      const currentFrame = getStateTimelineDuration(doc, machine, run.stateId);
       return {
         ...run,
-        currentFrame: getStateTimelineDuration(doc, machine, run.stateId),
+        currentFrame,
+        stateFrames: replaceCurrentStateFrame(run, currentFrame),
         playing: false,
         event: hasEventsToWaitFor ? run.event : eventName,
         finished: !hasEventsToWaitFor,
@@ -130,6 +138,7 @@ export function dispatchStateMachineRunEvent(
     previousStateId: run.stateId,
     activeTransitionId: transition.id,
     statePath: run.stateId === 'entry' ? [targetStateId] : [...run.statePath, targetStateId],
+    stateFrames: run.stateId === 'entry' ? [0] : [...replaceCurrentStateFrame(run, run.currentFrame), 0],
   }));
   return { ...next, changed: true };
 }
@@ -144,9 +153,13 @@ export function advanceStateMachineRunFrame(
   const duration = getStateTimelineDuration(doc, machine, run.stateId);
   const nextFrame = run.currentFrame + frameDelta;
   if (nextFrame > duration) {
-    return dispatchStateMachineRunEvent(doc, { ...run, currentFrame: duration }, 'complete');
+    return dispatchStateMachineRunEvent(doc, {
+      ...run,
+      currentFrame: duration,
+      stateFrames: replaceCurrentStateFrame(run, duration),
+    }, 'complete');
   }
-  return { ...run, currentFrame: nextFrame };
+  return { ...run, currentFrame: nextFrame, stateFrames: replaceCurrentStateFrame(run, nextFrame) };
 }
 
 export function getStateMachineRunVisualFrames(
@@ -155,6 +168,7 @@ export function getStateMachineRunVisualFrames(
 ): ElucimStateMachineVisualFrame[] {
   return getStateMachineVisualFrames(doc, run.machineId, {
     statePath: run.stateId === 'entry' ? ['entry'] : run.statePath,
+    stateFrames: run.stateFrames,
     currentStateId: run.stateId,
     currentFrame: run.currentFrame,
     exited: run.exited,
@@ -174,8 +188,12 @@ export function getStateMachineVisualFrames(
     return Object.entries(doc.timelines ?? {}).map(([timelineId, timeline]) => ({ timelineId, frame: timeline.duration }));
   }
   const path = options.statePath?.length ? options.statePath : [options.currentStateId];
-  const frames: ElucimStateMachineVisualFrame[] = Object.keys(doc.timelines ?? {}).map(timelineId => ({ timelineId, frame: 0 }));
-  for (const stateId of path) {
+  const frames: ElucimStateMachineVisualFrame[] = Object.keys(doc.timelines ?? {}).map(timelineId => ({
+    timelineId,
+    frame: 0,
+    includeContent: false,
+  }));
+  for (const [index, stateId] of path.entries()) {
     if (stateId === 'entry') continue;
     const state = machine.states[stateId];
     if (!state) {
@@ -190,7 +208,9 @@ export function getStateMachineVisualFrames(
     }
     frames.push({
       timelineId: state.timeline,
-      frame: stateId === options.currentStateId && !options.exited ? options.currentFrame : timeline.duration,
+      frame: stateId === options.currentStateId && !options.exited
+        ? options.currentFrame
+        : options.stateFrames?.[index] ?? timeline.duration,
     });
   }
   return frames;
@@ -274,7 +294,13 @@ function enterState(
   doc: ElucimDocument,
   machine: ElucimStateMachine,
   stateId: string,
-  details: { event: string; previousStateId?: string; activeTransitionId?: string; statePath?: string[] },
+  details: {
+    event: string;
+    previousStateId?: string;
+    activeTransitionId?: string;
+    statePath?: string[];
+    stateFrames?: number[];
+  },
 ): ElucimStateMachineRun {
   if (!machine.states[stateId]) throw new Error(`State "${stateId}" does not exist in machine "${machine.id}"`);
   const timelineId = machine.states[stateId].timeline;
@@ -284,6 +310,7 @@ function enterState(
     timelineId,
     statePath: details.statePath ?? [stateId],
     currentFrame: 0,
+    stateFrames: details.stateFrames ?? [0],
     playing: Boolean(timelineId && doc.timelines?.[timelineId]),
     event: details.event,
     previousStateId: details.previousStateId,
@@ -322,7 +349,17 @@ function settleImmediateTransitions(
     previousStateId: run.stateId,
     activeTransitionId: transition.id,
     statePath: [...run.statePath, targetStateId],
+    stateFrames: [...replaceCurrentStateFrame(run, run.currentFrame), 0],
   }), visited);
+}
+
+function replaceCurrentStateFrame(run: ElucimStateMachineRun, frame: number): number[] {
+  if (run.stateId === 'entry') return run.stateFrames;
+  const stateFrames = run.stateFrames.length === run.statePath.length
+    ? [...run.stateFrames]
+    : [...run.statePath.map(() => 0)];
+  stateFrames[stateFrames.length - 1] = frame;
+  return stateFrames;
 }
 
 function snapshot(machine: ElucimStateMachine, stateId: string): ElucimStateSnapshot {

--- a/packages/dsl/src/documentModel/timeline.ts
+++ b/packages/dsl/src/documentModel/timeline.ts
@@ -1,9 +1,11 @@
 import type {
   ElucimDocument,
+  ElucimRevealEffect,
   ElucimLayout,
   ElucimTimeline,
   ElucimTimelineTrack,
 } from './types';
+import type { RevealState } from '@elucim/core';
 import type { EasingSpec } from '../schema/types';
 
 export interface ElucimTimelinePatch {
@@ -16,12 +18,14 @@ export type ElucimTimelineFrame = Record<string, ElucimTimelinePatch>;
 export interface ElucimTimelineFrameSelection {
   timelineId: string;
   frame: number;
+  /** Whether text content tracks contribute to this selection. Default: true. */
+  includeContent?: boolean;
 }
 
 export function evaluateTimeline(timeline: ElucimTimeline, frame: number): ElucimTimelineFrame {
   const patches: ElucimTimelineFrame = {};
   const clampedFrame = Math.max(0, Math.min(frame, timeline.duration));
-  for (const track of timeline.tracks) {
+  for (const track of timeline.tracks ?? []) {
     const value = evaluateTrack(track, clampedFrame);
     const targetPatch = (patches[track.target] ??= {});
     if (track.property === 'translate' || track.property === 'scale' || track.property === 'rotate') {
@@ -42,13 +46,97 @@ export function applyTimelineFrame(doc: ElucimDocument, timelineId: string, fram
 
 export function applyTimelineFrames(doc: ElucimDocument, frames: ElucimTimelineFrameSelection[]): ElucimDocument {
   const next = cloneDoc(doc);
-  for (const { timelineId, frame } of frames) {
-    applyTimelineFrameToDocument(next, timelineId, frame);
+  for (const selection of frames) {
+    applyTimelineFrameToDocument(next, selection);
   }
   return next;
 }
 
-function applyTimelineFrameToDocument(doc: ElucimDocument, timelineId: string, frame: number): void {
+/** Resolves primitive reveal states from an ordered stack of timeline frames. */
+export function resolveTimelineReveals(
+  doc: ElucimDocument,
+  frames: ElucimTimelineFrameSelection[],
+): Record<string, RevealState> {
+  const reveals: Record<string, RevealState> = {};
+  for (const selection of frames) {
+    if (selection.includeContent === false) continue;
+    const timeline = doc.timelines?.[selection.timelineId];
+    if (!timeline) continue;
+    const selectionReveals: Record<string, { effect: ElucimRevealEffect; start: number }> = {};
+    for (const effect of timeline.effects ?? []) {
+      if (effect.kind !== 'reveal') continue;
+      const targets = resolveRevealTargets(doc, effect);
+      for (const [index, target] of targets.entries()) {
+        const offset = (effect.staggerInFrames ?? 0) * index;
+        const start = effect.from + offset;
+        const previous = selectionReveals[target];
+        if (
+          !previous
+          || (start <= selection.frame && previous.start > selection.frame)
+          || (start <= selection.frame && previous.start <= selection.frame && start >= previous.start)
+          || (start > selection.frame && previous.start > selection.frame && start < previous.start)
+        ) {
+          selectionReveals[target] = { effect, start };
+        }
+      }
+    }
+    for (const [target, assignment] of Object.entries(selectionReveals)) {
+      const { effect, start } = assignment;
+      reveals[target] = {
+        progress: clamp((selection.frame - start) / effect.duration),
+        strategy: resolveRevealStrategy(doc, target, effect),
+        ...(effect.cursor === undefined ? {} : { cursor: resolveRevealCursor(effect, selection.frame - start) }),
+      };
+    }
+  }
+  return reveals;
+}
+
+function resolveRevealTargets(doc: ElucimDocument, effect: ElucimRevealEffect): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  const visit = (id: string, ancestry: Set<string>) => {
+    if (ancestry.has(id)) throw new Error(`Reveal effect "${effect.id}" has a cyclic target tree at "${id}"`);
+    const element = doc.elements[id];
+    if (!element) throw new Error(`Reveal effect "${effect.id}" targets missing element "${id}"`);
+    if (element.children?.length) {
+      const nextAncestry = new Set(ancestry);
+      nextAncestry.add(id);
+      element.children.forEach(child => visit(child, nextAncestry));
+      return;
+    }
+    if (!seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  };
+  effect.targets.forEach(target => visit(target, new Set()));
+  return result;
+}
+
+function resolveRevealStrategy(
+  doc: ElucimDocument,
+  target: string,
+  effect: ElucimRevealEffect,
+): RevealState['strategy'] {
+  if (effect.strategy === 'fade') return 'fade';
+  if (effect.strategy === 'type') return doc.elements[target]?.type === 'text' ? 'type' : 'fade';
+  return doc.elements[target]?.type === 'text' ? 'type' : 'fade';
+}
+
+function resolveRevealCursor(effect: ElucimRevealEffect, elapsedFrames: number): RevealState['cursor'] {
+  if (effect.cursor === false || effect.cursor === true || effect.cursor === undefined) return effect.cursor;
+  const blinkEveryFrames = effect.cursor.blinkEveryFrames;
+  if (blinkEveryFrames && Math.floor(Math.max(0, elapsedFrames) / blinkEveryFrames) % 2 === 1) return false;
+  return effect.cursor;
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function applyTimelineFrameToDocument(doc: ElucimDocument, selection: ElucimTimelineFrameSelection): void {
+  const { timelineId, frame, includeContent = true } = selection;
   const timeline = doc.timelines?.[timelineId];
   if (!timeline) throw new Error(`Timeline "${timelineId}" does not exist`);
   const patches = evaluateTimeline(timeline, frame);
@@ -56,7 +144,10 @@ function applyTimelineFrameToDocument(doc: ElucimDocument, timelineId: string, f
     const element = doc.elements[id];
     if (!element) throw new Error(`Timeline "${timelineId}" targets missing element "${id}"`);
     element.layout = patch.layout ? { ...element.layout, ...patch.layout } : element.layout;
-    element.props = patch.props ? { ...element.props, ...patch.props } : element.props;
+    const props = includeContent || patch.props?.content === undefined
+      ? patch.props
+      : Object.fromEntries(Object.entries(patch.props).filter(([key]) => key !== 'content'));
+    element.props = props ? { ...element.props, ...props } : element.props;
   }
 }
 

--- a/packages/dsl/src/documentModel/types.ts
+++ b/packages/dsl/src/documentModel/types.ts
@@ -81,6 +81,7 @@ export type ElucimAnimatableProperty =
   | 'rotate'
   | 'fill'
   | 'stroke'
+  | 'content'
   | 'x'
   | 'dx'
   | 'from'
@@ -99,10 +100,36 @@ export interface ElucimTimelineTrack {
   keyframes: ElucimKeyframe[];
 }
 
+export type ElucimRevealStrategy = 'auto' | 'type' | 'fade';
+
+export interface ElucimRevealCursor {
+  character?: string;
+  blinkEveryFrames?: number;
+  hideWhenComplete?: boolean;
+}
+
+/**
+ * A procedural animation scheduled by a timeline rather than a property track.
+ *
+ * `duration` is the reveal duration for each resolved leaf target. When a
+ * target expands to several descendants, `staggerInFrames` offsets each leaf.
+ */
+export interface ElucimRevealEffect {
+  id: string;
+  kind: 'reveal';
+  targets: string[];
+  from: number;
+  duration: number;
+  strategy?: ElucimRevealStrategy;
+  staggerInFrames?: number;
+  cursor?: boolean | ElucimRevealCursor;
+}
+
 export interface ElucimTimeline {
   id: string;
   duration: number;
   tracks: ElucimTimelineTrack[];
+  effects?: ElucimRevealEffect[];
 }
 
 export interface ElucimStateMachine {

--- a/packages/dsl/src/documentModel/validateDocument.ts
+++ b/packages/dsl/src/documentModel/validateDocument.ts
@@ -2,7 +2,7 @@ import type { ElucimDocument, ElucimElement, ElucimTransition } from './types';
 import type { ValidationError, ValidationResult } from '../validator/validate';
 
 const VALID_ROOT_TYPES = new Set(['scene', 'player']);
-const VALID_TIMELINE_PROPERTIES = new Set(['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke', 'x', 'dx', 'from', 'to', 'n']);
+const VALID_TIMELINE_PROPERTIES = new Set(['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke', 'content', 'x', 'dx', 'from', 'to', 'n']);
 const RESERVED_EVENT_NAMES = new Set(['complete', 'entry', 'exit', 'next']);
 const LEGACY_WRAPPER_ELEMENT_TYPES = new Set(['sequence', 'fadein', 'fadeout', 'draw', 'write', 'transform', 'morph', 'stagger', 'parallel']);
 const LEGACY_ANIMATION_PROPS = new Set(['fadeIn', 'fadeOut', 'draw', 'write']);
@@ -85,6 +85,13 @@ function validateElement(id: string, element: ElucimElement, errors: ValidationE
           severity: 'error',
         });
       }
+    }
+    if (element.type === 'text' && 'typing' in element.props) {
+      errors.push({
+        path: `${path}.props.typing`,
+        message: 'Text typing is not a document property. Use a timeline reveal effect.',
+        severity: 'error',
+      });
     }
   }
   if (element.children !== undefined && !Array.isArray(element.children)) {
@@ -198,6 +205,8 @@ function validateTimelines(doc: ElucimDocument, errors: ValidationError[]) {
       }
       if (!VALID_TIMELINE_PROPERTIES.has(track.property)) {
         errors.push({ path: `${trackPath}.property`, message: `Unsupported animatable property "${String(track.property)}"`, severity: 'error' });
+      } else if (track.property === 'content' && doc.elements[track.target]?.type !== 'text') {
+        errors.push({ path: `${trackPath}.property`, message: 'The "content" timeline property can only target text elements', severity: 'error' });
       }
       if (!Array.isArray(track.keyframes) || track.keyframes.length === 0) {
         errors.push({ path: `${trackPath}.keyframes`, message: 'Track must have at least one keyframe', severity: 'error' });
@@ -218,10 +227,164 @@ function validateTimelines(doc: ElucimDocument, errors: ValidationError[]) {
           }
           if (keyframe.value === undefined) {
             errors.push({ path: `${keyframePath}.value`, message: 'Keyframe value is required', severity: 'error' });
+          } else if (track.property === 'content' && typeof keyframe.value !== 'string') {
+            errors.push({ path: `${keyframePath}.value`, message: 'Text content keyframes must use string values', severity: 'error' });
           }
         });
       }
+
     });
+    validateTimelineEffects(doc, timelineId, timeline, errors);
+  }
+}
+
+function validateTimelineEffects(
+  doc: ElucimDocument,
+  timelineId: string,
+  timeline: { duration: number; effects?: unknown },
+  errors: ValidationError[],
+): void {
+  if (timeline.effects === undefined) return;
+  if (!Array.isArray(timeline.effects)) {
+    errors.push({ path: `timelines.${timelineId}.effects`, message: 'Timeline effects must be an array', severity: 'error' });
+    return;
+  }
+  const effectIds = new Set<string>();
+  timeline.effects.forEach((effect, index) => {
+    const path = `timelines.${timelineId}.effects[${index}]`;
+    if (!effect || typeof effect !== 'object' || Array.isArray(effect)) {
+      errors.push({ path, message: 'Timeline effect must be an object', severity: 'error' });
+      return;
+    }
+    const reveal = effect as Record<string, unknown>;
+    if (typeof reveal.id !== 'string' || !reveal.id.trim()) {
+      errors.push({ path: `${path}.id`, message: 'Effect id must be a non-empty string', severity: 'error' });
+    } else if (effectIds.has(reveal.id)) {
+      errors.push({ path: `${path}.id`, message: `Duplicate effect id "${reveal.id}"`, severity: 'error' });
+    } else {
+      effectIds.add(reveal.id);
+    }
+    if (reveal.kind !== 'reveal') {
+      errors.push({ path: `${path}.kind`, message: 'Only "reveal" timeline effects are supported', severity: 'error' });
+      return;
+    }
+    if (!Array.isArray(reveal.targets) || reveal.targets.length === 0) {
+      errors.push({ path: `${path}.targets`, message: 'Reveal effects require at least one target', severity: 'error' });
+      return;
+    }
+    const targets = reveal.targets.filter((target): target is string => typeof target === 'string');
+    if (targets.length !== reveal.targets.length) {
+      errors.push({ path: `${path}.targets`, message: 'Reveal targets must be element ID strings', severity: 'error' });
+    }
+    const uniqueTargets = new Set(targets);
+    if (uniqueTargets.size !== targets.length) {
+      errors.push({ path: `${path}.targets`, message: 'Reveal targets must not contain duplicates', severity: 'error' });
+    }
+    targets.forEach((target, targetIndex) => {
+      if (!doc.elements[target]) {
+        errors.push({ path: `${path}.targets[${targetIndex}]`, message: `Unknown target "${target}"`, severity: 'error' });
+      }
+    });
+    validateRequiredNonNegativeInteger(reveal.from, `${path}.from`, errors);
+    validateRequiredPositiveInteger(reveal.duration, `${path}.duration`, errors);
+    validateNonNegativeInteger(reveal.staggerInFrames, `${path}.staggerInFrames`, errors);
+    if (reveal.strategy !== undefined && !['auto', 'type', 'fade'].includes(reveal.strategy as string)) {
+      errors.push({ path: `${path}.strategy`, message: 'Reveal strategy must be "auto", "type", or "fade"', severity: 'error' });
+    }
+    validateRevealCursor(reveal.cursor, `${path}.cursor`, errors);
+
+    const leafTargets = expandRevealTargets(doc, targets, path, errors);
+    if (reveal.strategy === 'type' && leafTargets?.some(target => doc.elements[target]?.type !== 'text')) {
+      errors.push({ path: `${path}.strategy`, message: 'The "type" reveal strategy can only target text leaves', severity: 'error' });
+    }
+    if (
+      Number.isInteger(reveal.from)
+      && Number.isInteger(reveal.duration)
+      && (reveal.staggerInFrames === undefined || Number.isInteger(reveal.staggerInFrames))
+      && leafTargets !== undefined
+    ) {
+      const lastFrame = (reveal.from as number)
+        + (reveal.duration as number)
+        + ((reveal.staggerInFrames as number | undefined) ?? 0) * Math.max(0, leafTargets.length - 1);
+      if (lastFrame > timeline.duration) {
+        errors.push({ path, message: 'Reveal effect completion cannot exceed timeline duration', severity: 'error' });
+      }
+    }
+  });
+}
+
+function validateRevealCursor(value: unknown, path: string, errors: ValidationError[]): void {
+  if (value === undefined || typeof value === 'boolean') return;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push({ path, message: 'Reveal cursor must be a boolean or object', severity: 'error' });
+    return;
+  }
+  const cursor = value as Record<string, unknown>;
+  if (cursor.character !== undefined && (typeof cursor.character !== 'string' || cursor.character.length === 0)) {
+    errors.push({ path: `${path}.character`, message: 'Reveal cursor character must be a non-empty string', severity: 'error' });
+  }
+  validatePositiveInteger(cursor.blinkEveryFrames, `${path}.blinkEveryFrames`, errors);
+  if (cursor.hideWhenComplete !== undefined && typeof cursor.hideWhenComplete !== 'boolean') {
+    errors.push({ path: `${path}.hideWhenComplete`, message: 'Reveal cursor hideWhenComplete must be a boolean', severity: 'error' });
+  }
+}
+
+function expandRevealTargets(
+  doc: ElucimDocument,
+  targets: string[],
+  path: string,
+  errors: ValidationError[],
+): string[] | undefined {
+  const leaves: string[] = [];
+  const seen = new Set<string>();
+  let valid = true;
+  const visit = (id: string, ancestry: Set<string>) => {
+    if (ancestry.has(id)) {
+      errors.push({ path, message: `Reveal target tree contains a cycle at "${id}"`, severity: 'error' });
+      valid = false;
+      return;
+    }
+    const element = doc.elements[id];
+    if (!element) {
+      valid = false;
+      return;
+    }
+    if (element.children?.length) {
+      const nextAncestry = new Set(ancestry);
+      nextAncestry.add(id);
+      element.children.forEach(child => visit(child, nextAncestry));
+      return;
+    }
+    if (!seen.has(id)) {
+      seen.add(id);
+      leaves.push(id);
+    }
+  };
+  targets.forEach(target => visit(target, new Set()));
+  return valid ? leaves : undefined;
+}
+
+function validateNonNegativeInteger(value: unknown, path: string, errors: ValidationError[]): void {
+  if (value !== undefined && (!Number.isInteger(value) || (value as number) < 0)) {
+    errors.push({ path, message: 'Must be a non-negative integer', severity: 'error' });
+  }
+}
+
+function validatePositiveInteger(value: unknown, path: string, errors: ValidationError[]): void {
+  if (value !== undefined && (!Number.isInteger(value) || (value as number) <= 0)) {
+    errors.push({ path, message: 'Must be a positive integer', severity: 'error' });
+  }
+}
+
+function validateRequiredNonNegativeInteger(value: unknown, path: string, errors: ValidationError[]): void {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    errors.push({ path, message: 'Must be a non-negative integer', severity: 'error' });
+  }
+}
+
+function validateRequiredPositiveInteger(value: unknown, path: string, errors: ValidationError[]): void {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    errors.push({ path, message: 'Must be a positive integer', severity: 'error' });
   }
 }
 

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -15,6 +15,9 @@ export type {
   ElucimGraphViewport,
   ElucimIntent,
   ElucimKeyframe,
+  ElucimRevealCursor,
+  ElucimRevealEffect,
+  ElucimRevealStrategy,
   ElucimLayout,
   ElucimMetadata,
   ElucimRepairHint,
@@ -94,6 +97,7 @@ export {
   evaluateTimeline,
   applyTimelineFrame,
   applyTimelineFrames,
+  resolveTimelineReveals,
 } from './documentModel/timeline';
 export {
   getInitialStateSnapshot,

--- a/packages/dsl/src/renderer/DslRenderer.tsx
+++ b/packages/dsl/src/renderer/DslRenderer.tsx
@@ -8,6 +8,7 @@ import {
   getDocumentLinearDuration,
   getInitialStateSnapshot,
   getStateMachineVisualFrames,
+  resolveTimelineReveals,
   toRenderableDocument,
 } from '../document';
 import { renderRoot } from './renderElements';
@@ -257,13 +258,36 @@ export const DslRenderer = forwardRef<DslRendererRef, DslRendererProps>(function
       : themeWithCompatibilityAliases(theme),
   ) as React.CSSProperties;
 
-  const posterRenderableDsl = poster !== undefined ? resolvePosterRenderableDsl(poster, dsl) : undefined;
+  const posterFrame = poster === undefined
+    ? undefined
+    : dsl.version === '2.0'
+      ? resolveDocumentPosterFrame(poster, dsl)
+      : resolvePoster(poster, dsl).frame;
+  const posterTimelineFrames = poster !== undefined && dsl.version === '2.0'
+    ? getPosterTimelineFrames(dsl, posterFrame!)
+    : undefined;
+  const posterRenderableDsl = poster !== undefined
+    ? resolvePosterRenderableDsl(poster, dsl, posterTimelineFrames)
+    : undefined;
+  const posterRevealStates = dsl.version === '2.0' && posterTimelineFrames
+    ? resolveTimelineReveals(dsl, posterTimelineFrames)
+    : undefined;
   const renderableDsl = stateMachineRuntime.renderableDsl ?? posterRenderableDsl ?? toRenderableDocument(dsl);
-  const posterOverrides = poster !== undefined && posterRenderableDsl === undefined ? resolvePoster(poster, renderableDsl) : undefined;
-  const rootOverrides = stateMachineRuntime.enabled ? { frame: stateMachineRuntime.frameOverride } : posterOverrides;
+  const rootOverrides = stateMachineRuntime.enabled
+    ? {
+      frame: stateMachineRuntime.frameOverride,
+      revealStates: stateMachineRuntime.revealStates,
+    }
+    : posterFrame === undefined
+      ? undefined
+      : {
+        frame: posterFrame,
+        revealStates: posterRevealStates,
+      };
 
   const content = renderRoot(renderableDsl.root, {
     frame: rootOverrides?.frame,
+    revealStates: rootOverrides?.revealStates,
     playerRef,
     colorScheme: resolvedColorScheme,
     controls,
@@ -301,11 +325,14 @@ function resolvePoster(poster: 'first' | 'last' | number, dsl: RenderableDocumen
   return { frame: poster };
 }
 
-function resolvePosterRenderableDsl(poster: 'first' | 'last' | number, dsl: ElucimDocument | RenderableDocument): RenderableDocument | undefined {
+function resolvePosterRenderableDsl(
+  poster: 'first' | 'last' | number,
+  dsl: ElucimDocument | RenderableDocument,
+  frames?: ElucimTimelineFrameSelection[],
+): RenderableDocument | undefined {
   if (dsl.version !== '2.0') return undefined;
-  const frame = resolveDocumentPosterFrame(poster, dsl);
-  const frames = getPosterTimelineFrames(dsl, frame);
-  const posterDoc = frames.length > 0 ? applyTimelineFrames(dsl, frames) : dsl;
+  const posterFrames = frames ?? getPosterTimelineFrames(dsl, resolveDocumentPosterFrame(poster, dsl));
+  const posterDoc = posterFrames.length > 0 ? applyTimelineFrames(dsl, posterFrames) : dsl;
   return createRenderableDocument(posterDoc);
 }
 

--- a/packages/dsl/src/renderer/renderElements.tsx
+++ b/packages/dsl/src/renderer/renderElements.tsx
@@ -8,9 +8,9 @@ import {
   Image, Group,
   Axes, FunctionPlot, SecantLine, TangentLine, RiemannSum, AccumulationArea,
   Vector, VectorField, Matrix, Graph, LaTeX, BarChart,
-  FadeIn, FadeOut, Draw, Write, Transform, Morph, Stagger, Parallel,
+  FadeIn, FadeOut, Draw, Write, Transform, Morph, Stagger, Parallel, RevealStateProvider,
 } from '@elucim/core';
-import type { TransitionType, PlayerRef } from '@elucim/core';
+import type { TransitionType, PlayerRef, RevealState } from '@elucim/core';
 import { resolveEasing } from './resolveEasing';
 import { resolveColor } from './resolveColor';
 import { compileExpression, compileVectorExpression } from '../math/evaluator';
@@ -34,6 +34,7 @@ function resolvePreset(preset?: ScenePreset, width?: number, height?: number): {
 
 export interface RenderRootOverrides {
   frame?: number;
+  revealStates?: Record<string, RevealState>;
   playerRef?: React.RefObject<PlayerRef | null>;
   /** CSS color-scheme to pass to Scene/Player. When set, overrides browser prefers-color-scheme. */
   colorScheme?: 'light' | 'dark' | 'light dark';
@@ -93,7 +94,7 @@ export function renderScene(node: SceneNode, overrides?: RenderRootOverrides): R
       fitToContainer={overrides?.fitToContainer}
       {...(hasFrameOverride ? { frame: overrides!.frame, autoPlay: false } : {})}
     >
-      {node.children.map((child, i) => renderElement(child, i))}
+      {node.children.map((child, i) => renderElement(child, i, overrides))}
     </Scene>
   );
 }
@@ -115,7 +116,7 @@ export function renderPlayer(node: PlayerNode, overrides?: RenderRootOverrides):
       fitToContainer={overrides?.fitToContainer}
       colorScheme={overrides?.colorScheme}
     >
-      {node.children.map((child, i) => renderElement(child, i))}
+      {node.children.map((child, i) => renderElement(child, i, overrides))}
     </Player>
   );
 }
@@ -133,28 +134,34 @@ export function renderPresentation(node: PresentationNode, overrides?: RenderRoo
       showNotes={node.showNotes}
       colorScheme={overrides?.colorScheme}
     >
-      {node.slides.map((slide, i) => renderSlide(slide, i))}
+      {node.slides.map((slide, i) => renderSlide(slide, i, overrides))}
     </Presentation>
   );
 }
 
-export function renderSlide(node: SlideNode, key: number): React.ReactNode {
+export function renderSlide(node: SlideNode, key: number, overrides?: RenderRootOverrides): React.ReactNode {
   return (
     <Slide key={key} title={node.title} notes={node.notes} background={resolveColor(node.background)}>
-      {node.children?.map((child, i) => renderElement(child, i))}
+      {node.children?.map((child, i) => renderElement(child, i, overrides))}
     </Slide>
   );
 }
 
 // ─── Element renderer ───────────────────────────────────────────────────────
 
-export function renderElement(node: ElementNode, key: number): React.ReactNode {
+export function renderElement(node: ElementNode, key: number, overrides?: RenderRootOverrides): React.ReactNode {
+  const element = renderElementNode(node, key, overrides);
+  const reveal = 'id' in node && node.id ? overrides?.revealStates?.[node.id] : undefined;
+  return reveal ? <RevealStateProvider key={key} state={reveal}>{element}</RevealStateProvider> : element;
+}
+
+function renderElementNode(node: ElementNode, key: number, overrides?: RenderRootOverrides): React.ReactNode {
   switch (node.type) {
     // Structural
     case 'sequence':
       return (
         <Sequence key={key} from={node.from} durationInFrames={node.durationInFrames} name={node.name}>
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Sequence>
       );
     case 'group':
@@ -167,7 +174,7 @@ export function renderElement(node: ElementNode, key: number): React.ReactNode {
           rotation={node.rotation} rotationOrigin={node.rotationOrigin}
           scale={node.scale} translate={node.translate}
         >
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Group>
       );
 
@@ -619,25 +626,25 @@ export function renderElement(node: ElementNode, key: number): React.ReactNode {
     case 'fadeIn':
       return (
         <FadeIn key={key} duration={node.duration} easing={resolveEasing(node.easing)}>
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </FadeIn>
       );
     case 'fadeOut':
       return (
         <FadeOut key={key} duration={node.duration} totalFrames={node.totalFrames} easing={resolveEasing(node.easing)}>
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </FadeOut>
       );
     case 'draw':
       return (
         <Draw key={key} duration={node.duration} pathLength={node.pathLength} easing={resolveEasing(node.easing)}>
-          {renderElement(node.children[0], 0) as React.ReactElement}
+          {renderElement(node.children[0], 0, overrides) as React.ReactElement}
         </Draw>
       );
     case 'write':
       return (
         <Write key={key} duration={node.duration} easing={resolveEasing(node.easing)}>
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Write>
       );
     case 'transform':
@@ -651,7 +658,7 @@ export function renderElement(node: ElementNode, key: number): React.ReactNode {
           rotate={node.rotate}
           opacity={node.opacity}
         >
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Transform>
       );
     case 'morph':
@@ -664,27 +671,27 @@ export function renderElement(node: ElementNode, key: number): React.ReactNode {
           fromOpacity={node.fromOpacity} toOpacity={node.toOpacity}
           fromScale={node.fromScale} toScale={node.toScale}
         >
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Morph>
       );
     case 'stagger':
       return (
         <Stagger key={key} staggerDelay={node.staggerDelay} easing={resolveEasing(node.easing)}>
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Stagger>
       );
     case 'parallel':
       return (
         <Parallel key={key}>
-          {node.children.map((child, i) => renderElement(child, i))}
+          {node.children.map((child, i) => renderElement(child, i, overrides))}
         </Parallel>
       );
 
     // Nested containers
     case 'scene':
-      return <React.Fragment key={key}>{renderScene(node)}</React.Fragment>;
+      return <React.Fragment key={key}>{renderScene(node, overrides)}</React.Fragment>;
     case 'player':
-      return <React.Fragment key={key}>{renderPlayer(node)}</React.Fragment>;
+      return <React.Fragment key={key}>{renderPlayer(node, overrides)}</React.Fragment>;
 
     default: {
       const _exhaustive: never = node;

--- a/packages/dsl/src/renderer/useStateMachineRuntime.ts
+++ b/packages/dsl/src/renderer/useStateMachineRuntime.ts
@@ -7,8 +7,10 @@ import {
   createRenderableDocument,
   dispatchStateMachineRunEvent,
   getStateMachineRunVisualFrames,
+  resolveTimelineReveals,
   startStateMachineRun,
 } from '../document';
+import type { RevealState } from '@elucim/core';
 
 interface StateMachineRuntimeOptions {
   dsl: RenderableDocument | ElucimDocument;
@@ -22,6 +24,7 @@ interface StateMachineRuntime {
   enabled: boolean;
   renderableDsl?: RenderableDocument;
   frameOverride?: number;
+  revealStates?: Record<string, RevealState>;
   getTotalFrames(): number;
   seekToFrame(frame: number): void;
   play(): void;
@@ -51,6 +54,8 @@ export function useStateMachineRuntime({
     if (!enabled || !stateMachineDocument || !stateMachineId) return null;
     return run?.machineId === stateMachineId ? run : startStateMachineRun(stateMachineDocument, stateMachineId);
   }, [enabled, run, stateMachineDocument, stateMachineId]);
+  const effectiveRunRef = React.useRef<ElucimStateMachineRun | null>(effectiveRun);
+  effectiveRunRef.current = effectiveRun;
 
   useEffect(() => {
     if (!enabled || !stateMachineDocument || !stateMachineId) {
@@ -61,13 +66,15 @@ export function useStateMachineRuntime({
   }, [enabled, stateMachineDocument, stateMachineId]);
 
   const triggerEvent = useCallback((event: string, key?: string) => {
-    if (!enabled || !stateMachineDocument || !effectiveRun) return false;
-    const next = dispatchStateMachineRunEvent(stateMachineDocument, effectiveRun, key ? { name: event, key } : event);
+    const currentRun = effectiveRunRef.current;
+    if (!enabled || !stateMachineDocument || !currentRun) return false;
+    const next = dispatchStateMachineRunEvent(stateMachineDocument, currentRun, key ? { name: event, key } : event);
     if (!next.changed) return false;
+    effectiveRunRef.current = next;
     setRun(next);
     onPlayStateChange?.(next.playing);
     return true;
-  }, [effectiveRun, enabled, onPlayStateChange, stateMachineDocument]);
+  }, [enabled, onPlayStateChange, stateMachineDocument]);
 
   useEffect(() => {
     if (!enabled || !stateMachineDocument || !effectiveRun?.playing) return;
@@ -83,9 +90,11 @@ export function useStateMachineRuntime({
           const next = advanceStateMachineRunFrame(stateMachineDocument, current, frameDelta);
           if (shouldLoop && stateMachineId && (next.finished || next.exited)) {
             const restarted = startStateMachineRun(stateMachineDocument, stateMachineId);
+            effectiveRunRef.current = restarted;
             if (next.playing !== restarted.playing) onPlayStateChange?.(restarted.playing);
             return restarted;
           }
+          effectiveRunRef.current = next;
           if (next.playing !== current.playing) onPlayStateChange?.(next.playing);
           return next;
         });
@@ -99,6 +108,9 @@ export function useStateMachineRuntime({
 
   const renderableDsl = enabled && stateMachineDocument && effectiveRun
     ? stateMachineRunToRenderableDocument(stateMachineDocument, effectiveRun)
+    : undefined;
+  const revealStates = enabled && stateMachineDocument && effectiveRun
+    ? resolveTimelineReveals(stateMachineDocument, getStateMachineRunVisualFrames(stateMachineDocument, effectiveRun))
     : undefined;
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -122,10 +134,23 @@ export function useStateMachineRuntime({
   return {
     enabled,
     renderableDsl,
-    frameOverride: enabled ? 0 : undefined,
+    frameOverride: enabled ? effectiveRun?.currentFrame : undefined,
+    revealStates,
     getTotalFrames: () => effectiveRun ? getRunDuration(stateMachineDocument, effectiveRun) + 1 : 0,
     seekToFrame: frame => {
-      setRun(current => current ? { ...current, currentFrame: Math.max(0, Math.min(frame, getRunDuration(stateMachineDocument, current))) } : current);
+      setRun(current => {
+        if (!current) return current;
+        const currentFrame = Math.max(0, Math.min(frame, getRunDuration(stateMachineDocument, current)));
+        const next = {
+          ...current,
+          currentFrame,
+          stateFrames: current.stateFrames.map((value, index) =>
+            index === current.stateFrames.length - 1 ? currentFrame : value,
+          ),
+        };
+        effectiveRunRef.current = next;
+        return next;
+      });
     },
     play: () => {
       if (shouldLoop && effectiveRun && (effectiveRun.finished || effectiveRun.exited) && stateMachineDocument && stateMachineId) {

--- a/packages/dsl/src/validator/validate.ts
+++ b/packages/dsl/src/validator/validate.ts
@@ -297,6 +297,9 @@ function validateText(node: Record<string, unknown>, path: string, errors: Valid
   if (node.wrap !== undefined && node.wrap !== 'none' && node.wrap !== 'word' && node.wrap !== 'char') {
     errors.push({ path: `${path}.wrap`, message: '"wrap" must be one of: none, word, char', severity: 'error' });
   }
+  if ('typing' in node) {
+    errors.push({ path: `${path}.typing`, message: 'Text typing is not supported in render-tree documents. Use a canonical timeline reveal effect.', severity: 'error' });
+  }
   validateAnimationProps(node, path, errors);
 }
 

--- a/packages/e2e/tests/text-reveal.spec.ts
+++ b/packages/e2e/tests/text-reveal.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('text reveal', () => {
+  test('reveals centered text and removes its cursor when playback completes', async ({ page }) => {
+    await page.goto('/');
+
+    const demo = page.locator('#text-demo');
+    const player = demo.getByTestId('elucim-player');
+    const text = player.getByTestId('elucim-text');
+    const cursor = player.getByTestId('elucim-text-cursor');
+
+    await expect(text).toHaveText('');
+    await expect(cursor).toHaveText('|');
+
+    const stepForward = player.getByTitle('Step forward');
+    for (let frame = 0; frame < 12; frame += 1) {
+      await stepForward.click();
+    }
+    await expect(text).toHaveText('Hello ');
+    await expect(cursor).toHaveText('|');
+
+    for (let frame = 0; frame < 12; frame += 1) {
+      await stepForward.click();
+    }
+    await expect(text).toHaveText('Hello Elucim');
+    await expect(cursor).toHaveCount(0);
+  });
+});

--- a/packages/editor/src/__tests__/inspector.test.ts
+++ b/packages/editor/src/__tests__/inspector.test.ts
@@ -173,6 +173,7 @@ describe('inspector textbox fields', () => {
     await waitFor(() => expect(latestTextbox?.fontWeight).toBe(700));
     cleanup();
   });
+
 });
 
 // ─── Style field updates ───────────────────────────────────────────────────

--- a/packages/editor/src/__tests__/timeline.test.ts
+++ b/packages/editor/src/__tests__/timeline.test.ts
@@ -6,12 +6,13 @@ import React, { useEffect } from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { editorReducer } from '../state/reducer';
 import { createInitialState } from '../state/types';
-import type { CircleNode, RectNode } from '@elucim/dsl';
+import type { CircleNode, RectNode, TextNode } from '@elucim/dsl';
 import { EditorProvider, useEditorState } from '../state/EditorProvider';
 import { Timeline } from '../timeline/Timeline';
 
 const circle: CircleNode = { type: 'circle', id: 'c1', cx: 100, cy: 100, r: 50, fadeIn: 20, fadeOut: 10, draw: 40 };
 const rect: RectNode = { type: 'rect', id: 'r1', x: 50, y: 50, width: 100, height: 80 };
+const typedText: TextNode = { type: 'text', id: 't1', x: 50, y: 50, content: '42' };
 
 afterEach(() => cleanup());
 
@@ -272,6 +273,33 @@ describe('canonical timeline clip rows', () => {
     rerender(renderEditableTimeline());
     fireEvent.click(screen.getByRole('button', { name: 'Remove intro r1.scale track' }));
     await waitFor(() => expect(latestTimelines.intro.tracks).toHaveLength(1));
+  });
+
+  it('preserves string values while editing text content tracks', async () => {
+    let latestTimelines: any;
+    const { rerender } = render(
+      React.createElement(
+        EditorProvider,
+        { initialDocument: { version: 'render-tree', root: { type: 'player', width: 800, height: 600, durationInFrames: 120, fps: 60, children: [typedText] } } },
+        React.createElement(Timeline, {
+          timelines: {
+            typing: {
+              id: 'typing',
+              duration: 20,
+              tracks: [{ target: 't1', property: 'content', keyframes: [{ frame: 0, value: '' }, { frame: 20, value: '42' }] }],
+            },
+          },
+          onTimelinesChange: timelines => { latestTimelines = timelines; },
+        }),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to typing t1.content keyframe 20' }));
+    fireEvent.change(screen.getByLabelText('typing t1.content keyframe 2 value'), { target: { value: '43' } });
+    fireEvent.blur(screen.getByLabelText('typing t1.content keyframe 2 value'));
+    await waitFor(() => expect(latestTimelines.typing.tracks[0].keyframes[1].value).toBe('43'));
+
+    rerender(React.createElement('div'));
   });
 
   it('renames canonical timelines and updates state machine timeline references', async () => {
@@ -906,5 +934,44 @@ describe('canonical timeline clip rows', () => {
       expect(latestTimelines.timeline.tracks[0].target).toBe('r1');
       expect(latestTimelines.timeline.tracks[0].property).toBe('opacity');
     });
+  });
+
+  it('authors a timeline-owned reveal effect instead of element-local typing', async () => {
+    let latestTimelines: any = {
+      intro: {
+        id: 'intro',
+        duration: 30,
+        tracks: [{ target: 'r1', property: 'opacity', keyframes: [{ frame: 0, value: 1 }] }],
+      },
+    };
+
+    render(
+      React.createElement(
+        EditorProvider,
+        {
+          initialDocument: {
+            version: 'render-tree',
+            root: { type: 'player', width: 800, height: 600, durationInFrames: 120, fps: 60, children: [rect] },
+          },
+        },
+        React.createElement(Timeline, {
+          timelines: latestTimelines,
+          onTimelinesChange: timelines => {
+            latestTimelines = timelines;
+          },
+        }),
+      ),
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add reveal to intro' }));
+
+    await waitFor(() => expect(latestTimelines.intro.effects).toEqual([{
+      id: 'reveal',
+      kind: 'reveal',
+      targets: ['r1'],
+      from: 0,
+      duration: 30,
+      strategy: 'auto',
+    }]));
   });
 });

--- a/packages/editor/src/timeline/Timeline.tsx
+++ b/packages/editor/src/timeline/Timeline.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useEffect, useMemo, useState } from 'react';
-import { DEFAULT_LINEAR_DURATION_IN_FRAMES, getMaxTimelineDuration, getStateMachineVisualFrames, type ElementNode, type ElucimDocument, type ElucimStateMachine, type ElucimTimeline, type ElucimTimelineFrameSelection, type ElucimTransition } from '@elucim/dsl';
+import { DEFAULT_LINEAR_DURATION_IN_FRAMES, getMaxTimelineDuration, getStateMachineVisualFrames, type ElementNode, type ElucimDocument, type ElucimRevealEffect, type ElucimStateMachine, type ElucimTimeline, type ElucimTimelineFrameSelection, type ElucimTransition } from '@elucim/dsl';
 import { BaseEdge, EdgeLabelRenderer, Handle, MarkerType, Position, ReactFlow, applyNodeChanges, getSmoothStepPath, type Edge, type EdgeProps, type Node, type NodeMouseHandler, type NodeProps, type OnConnect, type OnNodeDrag, type OnNodesChange, type ReactFlowInstance, type Viewport as ReactFlowViewport } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useEditorState } from '../state/EditorProvider';
@@ -149,6 +149,7 @@ export function Timeline({
   const elementIds = children.map((el, i) => getElementId(el, i));
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
   const rows = useMemo(() => getRows(children, expandedIds), [children, expandedIds]);
+  const elementTypes = useMemo(() => Object.fromEntries(rows.map(row => [row.id, row.element.type])), [rows]);
   const timelineClips = useMemo(() => Object.values(activeTimelines ?? {}), [activeTimelines]);
   const stateMachineClips = useMemo(() => Object.values(activeStateMachines ?? {}), [activeStateMachines]);
   const timelineDurationFallback = getMaxTimelineDuration(activeTimelines) ?? DEFAULT_LINEAR_DURATION_IN_FRAMES;
@@ -662,6 +663,7 @@ export function Timeline({
             onAddTimeline={onActiveTimelinesChange ? addBlankTimeline : undefined}
             onAddIntroTimeline={onActiveTimelinesChange ? addIntroTimeline : undefined}
             elementIds={rows.map(row => row.id)}
+            elementTypes={elementTypes}
             stateMachines={stateMachineClips}
             timelines={activeTimelines ?? {}}
             onStateMachineChange={onActiveStateMachinesChange ? updateStateMachine : undefined}
@@ -905,6 +907,7 @@ function TimelineClipRows({
   onAddTimeline,
   onAddIntroTimeline,
   elementIds,
+  elementTypes,
   stateMachines,
   timelines,
   onStateMachineChange,
@@ -941,6 +944,7 @@ function TimelineClipRows({
   onAddTimeline?: () => void;
   onAddIntroTimeline?: () => void;
   elementIds: string[];
+  elementTypes: Record<string, string>;
   stateMachines: ElucimStateMachine[];
   timelines: Record<string, ElucimTimeline>;
   onStateMachineChange?: (machine: ElucimStateMachine) => void;
@@ -1194,6 +1198,9 @@ function TimelineClipRows({
         : track),
     });
     selectMotionItem({ type: 'animation', timelineId: clip.id, trackIndex });
+  };
+  const updateEffects = (clip: ElucimTimeline, effects: ElucimRevealEffect[]) => {
+    onTimelineChange?.({ ...clip, effects });
   };
   const dragKeyframe = (event: React.PointerEvent<HTMLButtonElement>, clip: ElucimTimeline, trackIndex: number, keyframeIndex: number) => {
     if (!onTimelineChange) return;
@@ -2116,11 +2123,13 @@ function TimelineClipRows({
             keyframe={selectedKeyframe}
             selectedItem={selectedItem?.type === 'animation' ? selectedItem : null}
             elementIds={elementIds}
+            elementTypes={elementTypes}
             onRenameClip={renameClip}
             onUpdateDuration={updateDuration}
             onUpdateTrack={updateTrack}
             onUpdateKeyframe={updateKeyframe}
             onDeleteKeyframe={deleteKeyframe}
+            onUpdateEffects={updateEffects}
           />
         )}
       </div>

--- a/packages/editor/src/timeline/TimelineInspector.tsx
+++ b/packages/editor/src/timeline/TimelineInspector.tsx
@@ -1,4 +1,4 @@
-import type { ElucimTimeline } from '@elucim/dsl';
+import type { ElucimRevealEffect, ElucimTimeline } from '@elucim/dsl';
 import { v } from '../theme/tokens';
 import { ANIMATABLE_PROPERTIES } from './constants';
 import { parseKeyframeValue } from './keyframeValue';
@@ -11,22 +11,26 @@ export function TimelineInspector({
   keyframe,
   selectedItem,
   elementIds,
+  elementTypes,
   onRenameClip,
   onUpdateDuration,
   onUpdateTrack,
   onUpdateKeyframe,
   onDeleteKeyframe,
+  onUpdateEffects,
 }: {
   clip?: ElucimTimeline;
   track?: TimelineTrack;
   keyframe?: TimelineKeyframe;
   selectedItem: SelectedTimelineItem | null;
   elementIds: string[];
+  elementTypes: Record<string, string>;
   onRenameClip?: (clip: ElucimTimeline, nextId: string) => void;
   onUpdateDuration: (clip: ElucimTimeline, duration: number) => void;
   onUpdateTrack: (clip: ElucimTimeline, trackIndex: number, patch: Partial<TimelineTrack>) => void;
   onUpdateKeyframe: (clip: ElucimTimeline, trackIndex: number, keyframeIndex: number, patch: { frame?: number; value?: unknown }) => void;
   onDeleteKeyframe: (clip: ElucimTimeline, trackIndex: number, keyframeIndex: number) => void;
+  onUpdateEffects: (clip: ElucimTimeline, effects: ElucimRevealEffect[]) => void;
 }) {
   if (!clip) {
     return <div style={{ ...motionInspectorPanelStyle, color: v('--elucim-editor-text-muted'), fontSize: 11 }}>Select a timeline to edit details.</div>;
@@ -41,7 +45,7 @@ export function TimelineInspector({
   };
   const commitKeyframeValue = (value: string) => {
     if (!keyframe || selectedItem?.trackIndex === undefined || selectedItem.keyframeIndex === undefined) return;
-    const nextValue = parseKeyframeValue(value);
+    const nextValue = track?.property === 'content' ? value : parseKeyframeValue(value);
     if (nextValue !== keyframe.value) onUpdateKeyframe(clip, selectedItem.trackIndex, selectedItem.keyframeIndex, { value: nextValue });
   };
   const commitDuration = (value: string) => {
@@ -49,12 +53,47 @@ export function TimelineInspector({
     const numeric = Number(value);
     if (Number.isFinite(numeric) && numeric !== clip.duration) onUpdateDuration(clip, numeric);
   };
+  const effects = clip.effects ?? [];
+  const updateEffect = (effectIndex: number, patch: Partial<ElucimRevealEffect>) => {
+    onUpdateEffects(clip, effects.map((effect, index) => index === effectIndex ? { ...effect, ...patch } : effect));
+  };
+  const updateEffectNumber = (effectIndex: number, field: 'from' | 'duration' | 'staggerInFrames', value: string) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return;
+    const effect = effects[effectIndex];
+    if (!effect) return;
+    const targetCount = Math.max(1, effect.targets.length);
+    const stagger = effect.staggerInFrames ?? 0;
+    const maxStart = Math.max(0, clip.duration - effect.duration - stagger * (targetCount - 1));
+    const maxDuration = Math.max(1, clip.duration - effect.from - stagger * (targetCount - 1));
+    const maxStagger = targetCount === 1
+      ? clip.duration
+      : Math.max(0, Math.floor((clip.duration - effect.from - effect.duration) / (targetCount - 1)));
+    const maximum = field === 'from' ? maxStart : field === 'duration' ? maxDuration : maxStagger;
+    updateEffect(effectIndex, { [field]: Math.max(field === 'duration' ? 1 : 0, Math.min(maximum, Math.round(numeric))) });
+  };
+  const addRevealEffect = () => {
+    const existingIds = new Set(effects.map(effect => effect.id));
+    let id = 'reveal';
+    let suffix = 2;
+    while (existingIds.has(id)) id = `reveal-${suffix++}`;
+    onUpdateEffects(clip, [...effects, {
+      id,
+      kind: 'reveal',
+      targets: elementIds.length > 0 ? [elementIds[0]] : [],
+      from: 0,
+      duration: Math.min(30, clip.duration),
+      strategy: 'auto',
+    }]);
+  };
   return (
     <aside style={motionInspectorPanelStyle}>
       <div>
         <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6 }}>Animation details</div>
         <div style={{ color: v('--elucim-editor-fg'), fontWeight: 700 }}>{clip.id}</div>
-        <div style={{ color: v('--elucim-editor-text-secondary'), fontSize: 10 }}>{clip.tracks.length} track{clip.tracks.length === 1 ? '' : 's'}</div>
+        <div style={{ color: v('--elucim-editor-text-secondary'), fontSize: 10 }}>
+          {clip.tracks.length} track{clip.tracks.length === 1 ? '' : 's'} · {effects.length} reveal{effects.length === 1 ? '' : 's'}
+        </div>
       </div>
       <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
         Name
@@ -69,6 +108,157 @@ export function TimelineInspector({
           style={inspectorInputStyle}
         />
       </label>
+      <div style={{ display: 'grid', gap: 6, paddingTop: 6, borderTop: `1px solid ${v('--elucim-editor-border-subtle')}` }}>
+        <div style={{ color: v('--elucim-editor-text-muted'), fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.6 }}>Reveal effects</div>
+        {effects.map((effect, effectIndex) => {
+          const cursor = typeof effect.cursor === 'object' ? effect.cursor : undefined;
+          const canTypeTargets = effect.targets.length > 0 && effect.targets.every(target => elementTypes[target] === 'text');
+          return (
+            <div key={effect.id} style={{ display: 'grid', gap: 5, padding: 6, border: `1px solid ${v('--elucim-editor-border-subtle')}`, borderRadius: 4 }}>
+              <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                Effect ID
+                <input
+                  aria-label={`${clip.id} reveal ${effectIndex + 1} ID`}
+                  value={effect.id}
+                  onChange={event => updateEffect(effectIndex, { id: event.target.value })}
+                  style={inspectorInputStyle}
+                />
+              </label>
+              <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                Targets
+                <input
+                  aria-label={`${clip.id} reveal ${effectIndex + 1} targets`}
+                  value={effect.targets.join(', ')}
+                  onChange={event => updateEffect(effectIndex, {
+                    targets: event.target.value.split(',').map(value => value.trim()).filter(Boolean),
+                  })}
+                  style={inspectorInputStyle}
+                />
+              </label>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 5 }}>
+                <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                  Start
+                  <input
+                    aria-label={`${clip.id} reveal ${effectIndex + 1} start`}
+                    type="number"
+                    min={0}
+                    max={clip.duration}
+                    value={effect.from}
+                    onChange={event => updateEffectNumber(effectIndex, 'from', event.target.value)}
+                    style={inspectorInputStyle}
+                  />
+                </label>
+                <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                  Duration
+                  <input
+                    aria-label={`${clip.id} reveal ${effectIndex + 1} duration`}
+                    type="number"
+                    min={1}
+                    max={clip.duration}
+                    value={effect.duration}
+                    onChange={event => updateEffectNumber(effectIndex, 'duration', event.target.value)}
+                    style={inspectorInputStyle}
+                  />
+                </label>
+              </div>
+              <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                Strategy
+                <select
+                  aria-label={`${clip.id} reveal ${effectIndex + 1} strategy`}
+                  value={effect.strategy ?? 'auto'}
+                  onChange={event => updateEffect(effectIndex, { strategy: event.target.value as ElucimRevealEffect['strategy'] })}
+                  style={inspectorInputStyle}
+                >
+                  <option value="auto">Auto</option>
+                  {canTypeTargets && <option value="type">Type text</option>}
+                  <option value="fade">Fade</option>
+                </select>
+              </label>
+              <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                Stagger
+                <input
+                  aria-label={`${clip.id} reveal ${effectIndex + 1} stagger`}
+                  type="number"
+                  min={0}
+                  value={effect.staggerInFrames ?? 0}
+                  onChange={event => updateEffectNumber(effectIndex, 'staggerInFrames', event.target.value)}
+                  style={inspectorInputStyle}
+                />
+              </label>
+              <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                Cursor
+                <select
+                  aria-label={`${clip.id} reveal ${effectIndex + 1} cursor`}
+                  value={effect.cursor === false ? 'off' : 'on'}
+                  onChange={event => updateEffect(effectIndex, { cursor: event.target.value === 'on' ? (cursor ?? true) : false })}
+                  style={inspectorInputStyle}
+                >
+                  <option value="on">On</option>
+                  <option value="off">Off</option>
+                </select>
+              </label>
+              {effect.cursor !== false && (
+                <>
+                  <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                    Cursor character
+                    <input
+                      aria-label={`${clip.id} reveal ${effectIndex + 1} cursor character`}
+                      value={cursor?.character ?? ''}
+                      onChange={event => updateEffect(effectIndex, { cursor: { ...cursor, character: event.target.value || undefined } })}
+                      style={inspectorInputStyle}
+                    />
+                  </label>
+                  <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                    Cursor blink
+                    <input
+                      aria-label={`${clip.id} reveal ${effectIndex + 1} cursor blink`}
+                      type="number"
+                      min={1}
+                      value={cursor?.blinkEveryFrames ?? ''}
+                      onChange={event => {
+                        const value = event.target.value === '' ? undefined : Math.max(1, Math.round(Number(event.target.value)));
+                        updateEffect(effectIndex, { cursor: { ...cursor, blinkEveryFrames: value } });
+                      }}
+                      style={inspectorInputStyle}
+                    />
+                  </label>
+                  <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
+                    Hide cursor
+                    <select
+                      aria-label={`${clip.id} reveal ${effectIndex + 1} hide cursor`}
+                      value={cursor?.hideWhenComplete === false ? 'no' : 'yes'}
+                      onChange={event => updateEffect(effectIndex, {
+                        cursor: { ...cursor, hideWhenComplete: event.target.value === 'yes' },
+                      })}
+                      style={inspectorInputStyle}
+                    >
+                      <option value="yes">After reveal</option>
+                      <option value="no">Never</option>
+                    </select>
+                  </label>
+                </>
+              )}
+              <button
+                type="button"
+                aria-label={`Remove ${clip.id} reveal ${effectIndex + 1}`}
+                onClick={() => onUpdateEffects(clip, effects.filter((_, index) => index !== effectIndex))}
+                style={{ border: `1px solid ${v('--elucim-editor-border')}`, borderRadius: 4, background: 'transparent', color: v('--elucim-editor-text-secondary'), cursor: 'pointer', padding: '4px 6px', textAlign: 'left' }}
+              >
+                Remove reveal
+              </button>
+            </div>
+          );
+        })}
+        <button
+          type="button"
+          aria-label={`Add reveal to ${clip.id}`}
+          onClick={addRevealEffect}
+          disabled={elementIds.length === 0}
+          style={{ border: `1px solid ${v('--elucim-editor-border')}`, borderRadius: 4, background: 'transparent', color: v('--elucim-editor-fg'), cursor: elementIds.length ? 'pointer' : 'not-allowed', padding: '4px 6px', textAlign: 'left' }}
+        >
+          Add reveal
+        </button>
+      </div>
       <label style={{ display: 'grid', gap: 3, color: v('--elucim-editor-text-secondary') }}>
         Duration
         <input
@@ -109,7 +299,9 @@ export function TimelineInspector({
               onChange={event => onUpdateTrack(clip, selectedItem.trackIndex!, { property: event.target.value as TimelineTrack['property'] })}
               style={inspectorInputStyle}
             >
-              {ANIMATABLE_PROPERTIES.map(property => <option key={property} value={property}>{property}</option>)}
+              {ANIMATABLE_PROPERTIES
+                .filter(property => property !== 'content' || elementTypes[track.target] === 'text')
+                .map(property => <option key={property} value={property}>{property}</option>)}
             </select>
           </label>
         </>

--- a/packages/editor/src/timeline/constants.ts
+++ b/packages/editor/src/timeline/constants.ts
@@ -25,7 +25,7 @@ export const EASING_OPTIONS = [
   'easeOutBack',
 ];
 
-export const ANIMATABLE_PROPERTIES = ['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke'] as const;
+export const ANIMATABLE_PROPERTIES = ['opacity', 'translate', 'scale', 'rotate', 'fill', 'stroke', 'content'] as const;
 export const WRAPPER_TYPES = new Set(['fadeIn', 'fadeOut', 'draw', 'write', 'transform', 'morph', 'stagger', 'parallel']);
 
 export const ENTRY_NODE_ID = '__entry__';


### PR DESCRIPTION
## Summary
- add canonical timeline reveal effects with typed text, fade fallback, cursor behavior, staggering, validation, editor authoring, and React `Reveal`
- compose reveal, document, and scene-camera projections through one ordered state-machine frame selection stack
- make static SVG/PNG output preserve selected state-machine camera and reveal effects

## Validation
- `pnpm test`
- `pnpm build`
- Chromium Playwright: `text-reveal.spec.ts` and `scene-camera.spec.ts`